### PR TITLE
auto-merge-develop workflow の git identity 未設定によるマージ失敗を修正

### DIFF
--- a/.github/workflows/auto-merge-develop.yml
+++ b/.github/workflows/auto-merge-develop.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Merge develop into main
         if: success()
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
           git fetch origin main
 
           git checkout main


### PR DESCRIPTION
## 本 PR に対応する Issue

対応する Issue は存在しない。`develop` への push をきっかけに `main` へ自動マージするワークフローの実行が失敗していることに気づいたため、緊急の修正として対応する。

## 本 PR で行った変更の概要

`.github/workflows/auto-merge-develop.yml` の `Merge develop into main` ステップで `git merge --no-ff` によるマージコミット作成が `fatal: empty ident name ... not allowed` で失敗していた。CI ランナー上で `git` の `user.name` / `user.email` を設定していなかったことが原因である。

このステップの先頭で `git config user.name`/`user.email` を `github-actions[bot]` の identity に設定するよう変更した。

この不具合により、`origin/main` は `origin/develop` から 30 コミット以上遅れた状態になっている。本 PR がマージされ `develop` へ push されると、修正済みの workflow が発火し、`origin/develop` 全体を `--no-ff` でマージするため、この遅延分もまとめて `main` に反映される見込みである。

## 動作を確認する手順

1. 本 PR を `develop` にマージする
2. GitHub Actions の `Auto merge develop into main` ワークフローが起動し、成功で完了することを確認する
3. `origin/main` が `origin/develop` に追従し、コミットの遅延が解消されていることを確認する

## 影響を受けるドキュメントの更新

- [ ] README — 導入・概要に影響する変更があれば更新した
- [ ] docs（reference / explanation）— 現在の仕様や設計の説明に影響する変更があれば更新した
- [ ] ADR — 将来を縛る設計判断をした場合は ADR を追加または supersede した
- [ ] CHANGELOG — 利用者向けの変更点を Unreleased に追記した

更新が不要な理由: CI ワークフローの不具合修正のみであり、利用者向けの仕様・挙動・公開 API に変更はないため。

*This comment was posted by AI Agent.*
