### PR TITLE
最大流 (Dinic法) と最小費用流を追加する

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -418,6 +418,78 @@ path = "src/bin/atcoder/bundled/typical90_bs_fuzzy_priority.rs"
 required-features = ["bundled"]
 
 [[bin]]
+name = "ac-arc085-e-mul"
+path = "src/bin/atcoder/arc085_e_mul.rs"
+
+[[bin]]
+name = "ac-arc085-e-mul-bundled"
+path = "src/bin/atcoder/bundled/arc085_e_mul.rs"
+required-features = ["bundled"]
+
+[[bin]]
+name = "ac-typical90-an-get-more-money"
+path = "src/bin/atcoder/typical90_an_get_more_money.rs"
+
+[[bin]]
+name = "ac-typical90-an-get-more-money-bundled"
+path = "src/bin/atcoder/bundled/typical90_an_get_more_money.rs"
+required-features = ["bundled"]
+
+[[bin]]
+name = "ac-abc326-g-unlock-achievement"
+path = "src/bin/atcoder/abc326_g_unlock_achievement.rs"
+
+[[bin]]
+name = "ac-abc326-g-unlock-achievement-bundled"
+path = "src/bin/atcoder/bundled/abc326_g_unlock_achievement.rs"
+required-features = ["bundled"]
+
+[[bin]]
+name = "ac-abc225-g-x"
+path = "src/bin/atcoder/abc225_g_x.rs"
+
+[[bin]]
+name = "ac-abc225-g-x-bundled"
+path = "src/bin/atcoder/bundled/abc225_g_x.rs"
+required-features = ["bundled"]
+
+[[bin]]
+name = "ac-abc193-f-zebraness"
+path = "src/bin/atcoder/abc193_f_zebraness.rs"
+
+[[bin]]
+name = "ac-abc193-f-zebraness-bundled"
+path = "src/bin/atcoder/bundled/abc193_f_zebraness.rs"
+required-features = ["bundled"]
+
+[[bin]]
+name = "poj-poj2987-firing"
+path = "src/bin/poj/poj2987_firing.rs"
+
+[[bin]]
+name = "poj-poj2987-firing-bundled"
+path = "src/bin/poj/bundled/poj2987_firing.rs"
+required-features = ["bundled"]
+
+[[bin]]
+name = "yuki-yuki2713-just-solitaire"
+path = "src/bin/yukicoder/yuki2713_just_solitaire.rs"
+
+[[bin]]
+name = "yuki-yuki2713-just-solitaire-bundled"
+path = "src/bin/yukicoder/bundled/yuki2713_just_solitaire.rs"
+required-features = ["bundled"]
+
+[[bin]]
+name = "cf-cf1082g-petya-and-graph"
+path = "src/bin/codeforces/cf1082g_petya_and_graph.rs"
+
+[[bin]]
+name = "cf-cf1082g-petya-and-graph-bundled"
+path = "src/bin/codeforces/bundled/cf1082g_petya_and_graph.rs"
+required-features = ["bundled"]
+
+[[bin]]
 name = "ac-practice2-d-maxflow"
 path = "src/bin/atcoder/practice2_d_maxflow.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,15 @@ path = "src/bin/library_checker/bundled/minimum_spanning_tree.rs"
 required-features = ["bundled"]
 
 [[bin]]
+name = "lc-assignment"
+path = "src/bin/library_checker/assignment.rs"
+
+[[bin]]
+name = "lc-assignment-bundled"
+path = "src/bin/library_checker/bundled/assignment.rs"
+required-features = ["bundled"]
+
+[[bin]]
 name = "lc-convolution-mod"
 path = "src/bin/library_checker/convolution_mod.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -408,5 +408,14 @@ name = "ac-typical90-bs-fuzzy-priority-bundled"
 path = "src/bin/atcoder/bundled/typical90_bs_fuzzy_priority.rs"
 required-features = ["bundled"]
 
+[[bin]]
+name = "ac-practice2-d-maxflow"
+path = "src/bin/atcoder/practice2_d_maxflow.rs"
+
+[[bin]]
+name = "ac-practice2-d-maxflow-bundled"
+path = "src/bin/atcoder/bundled/practice2_d_maxflow.rs"
+required-features = ["bundled"]
+
 [dev-dependencies]
 rstest = "0.26.1"

--- a/src/bin/atcoder/abc193_f_zebraness.rs
+++ b/src/bin/atcoder/abc193_f_zebraness.rs
@@ -1,0 +1,65 @@
+// AtCoder: ABC193-F - Zebraness
+// https://atcoder.jp/contests/abc193/tasks/abc193_f
+
+use anmitsu::graph::project_selection::ProjectSelection;
+use anmitsu::io::fastio::Fastio;
+
+fn main() {
+    let mut io = Fastio::new();
+
+    let n = io.u32() as usize;
+    let grid = (0..n).map(|_| io.chars()).collect::<Vec<Vec<char>>>();
+
+    let cell = |r: usize, c: usize| r * n + c;
+    let n_cells = n * n;
+    let n_edges = 2 * n * n.saturating_sub(1);
+    let mut psp = ProjectSelection::<i64>::new(n_cells + 2 * n_edges);
+    let mut next_aux = n_cells;
+
+    // グリッド上で隣接する2マスは、必ずマス目の (行番号+列番号) の偶奇が
+    // 異なる。そこで各マスに y = (色) XOR (行番号+列番号の偶奇) という値を
+    // 割り当てると、隣接する2マスの色が異なることと y が等しいことが同値に
+    // なる (偶奇の差がちょうど反転を打ち消すため)。この y を「選ぶ/選ばない」
+    // の2値とみなし、色が確定しているマスは force_selected/force_unselected
+    // で固定する。
+    for (r, row) in grid.iter().enumerate() {
+        for (c, &ch) in row.iter().enumerate() {
+            if ch == '?' {
+                continue;
+            }
+            let color = usize::from(ch == 'B');
+            let parity = (r + c) % 2;
+            if color ^ parity == 1 {
+                psp.force_selected(cell(r, c));
+            } else {
+                psp.force_unselected(cell(r, c));
+            }
+        }
+    }
+
+    let mut add_edge_bonus = |psp: &mut ProjectSelection<i64>, u: usize, v: usize| {
+        let aux1 = next_aux;
+        next_aux += 1;
+        let aux2 = next_aux;
+        next_aux += 1;
+        // y が両方1、または両方0 (すなわち色が異なる) であれば、しまうま度が
+        // 1 増える。
+        psp.add_and_bonus_when_selected(&[u, v], 1, aux1);
+        psp.add_and_bonus_when_unselected(&[u, v], 1, aux2);
+    };
+    for r in 0..n {
+        for c in 0..n.saturating_sub(1) {
+            add_edge_bonus(&mut psp, cell(r, c), cell(r, c + 1));
+        }
+    }
+    for r in 0..n.saturating_sub(1) {
+        for c in 0..n {
+            add_edge_bonus(&mut psp, cell(r, c), cell(r + 1, c));
+        }
+    }
+
+    let (ans, _) = psp.solve();
+    io.writeln(ans);
+
+    io.flush();
+}

--- a/src/bin/atcoder/abc225_g_x.rs
+++ b/src/bin/atcoder/abc225_g_x.rs
@@ -1,0 +1,54 @@
+// AtCoder: ABC225-G - X
+// https://atcoder.jp/contests/abc225/tasks/abc225_g
+
+use anmitsu::graph::project_selection::ProjectSelection;
+use anmitsu::io::fastio::Fastio;
+
+fn main() {
+    let mut io = Fastio::new();
+
+    let h = io.u32() as usize;
+    let w = io.u32() as usize;
+    let c = io.i64();
+    let a = (0..h)
+        .map(|_| (0..w).map(|_| io.i64()).collect::<Vec<i64>>())
+        .collect::<Vec<Vec<i64>>>();
+
+    let cell = |r: usize, cl: usize| r * w + cl;
+    let n_cells = h * w;
+    // 斜めに隣接するマスの組ごとに、線分を共有できた場合の得を表す補助頂点を
+    // 1つずつ使う。組の総数は高々 2 * (h-1) * (w-1) である。
+    let n_aux = 2 * h.saturating_sub(1) * w.saturating_sub(1);
+    let mut psp = ProjectSelection::<i64>::new(n_cells + n_aux);
+    let mut next_aux = n_cells;
+
+    for (r, row) in a.iter().enumerate() {
+        for (cl, &value) in row.iter().enumerate() {
+            // マスを選ぶ (バツ印を付ける) と、そのマスの値を得られる代わりに、
+            // 自分自身の左上-右下・右上-左下の2本の線分の分だけコストがかかる。
+            psp.add_weight(cell(r, cl), value - 2 * c);
+        }
+    }
+    for r in 0..h.saturating_sub(1) {
+        for cl in 0..w.saturating_sub(1) {
+            // "\" 方向に隣接するマスの左上-右下の線分は、両方選ばれていれば
+            // 1本にまとめて描けるため、その分のコスト c が浮く。
+            let aux = next_aux;
+            next_aux += 1;
+            psp.add_and_bonus_when_selected(&[cell(r, cl), cell(r + 1, cl + 1)], c, aux);
+        }
+    }
+    for r in 0..h.saturating_sub(1) {
+        for cl in 1..w {
+            // "/" 方向に隣接するマスの右上-左下の線分も、同様にまとめられる。
+            let aux = next_aux;
+            next_aux += 1;
+            psp.add_and_bonus_when_selected(&[cell(r, cl), cell(r + 1, cl - 1)], c, aux);
+        }
+    }
+
+    let (ans, _) = psp.solve();
+    io.writeln(ans);
+
+    io.flush();
+}

--- a/src/bin/atcoder/abc326_g_unlock_achievement.rs
+++ b/src/bin/atcoder/abc326_g_unlock_achievement.rs
@@ -1,0 +1,52 @@
+// AtCoder: ABC326-G - Unlock Achievement
+// https://atcoder.jp/contests/abc326/tasks/abc326_g
+
+use anmitsu::graph::project_selection::ProjectSelection;
+use anmitsu::io::fastio::Fastio;
+
+fn main() {
+    let mut io = Fastio::new();
+
+    let n = io.u32() as usize;
+    let m = io.u32() as usize;
+    let c = (0..n).map(|_| io.i64()).collect::<Vec<i64>>();
+    let a = (0..m).map(|_| io.i64()).collect::<Vec<i64>>();
+
+    // スキル j をレベル k (2..=5) まで上げた状態を表す頂点。レベル1は
+    // 何もしなくても最初から達成しているため、頂点を用意しない。
+    let skill_vertex = |j: usize, k: usize| j * 4 + (k - 2);
+    let n_skill_vertices = n * 4;
+
+    let mut psp = ProjectSelection::<i64>::new(n_skill_vertices + m);
+    for (j, &cj) in c.iter().enumerate() {
+        for k in 2..=5 {
+            // レベル k まで上げるには、レベル k-1 からレベル k へ上げる分の
+            // コスト c[j] が必ずかかる。
+            psp.add_weight(skill_vertex(j, k), -cj);
+        }
+        for k in 3..=5 {
+            // レベル k まで上げているなら、レベル k-1 までも上げていなければ
+            // ならない。
+            psp.add_constraint(skill_vertex(j, k), skill_vertex(j, k - 1));
+        }
+    }
+
+    let l = (0..m)
+        .map(|_| (0..n).map(|_| io.u32() as usize).collect::<Vec<usize>>())
+        .collect::<Vec<Vec<usize>>>();
+
+    for (i, row) in l.iter().enumerate() {
+        // レベル1以上の条件は最初から満たされているため、レベル2以上を
+        // 要求する条件だけを集める。
+        let required = (0..n)
+            .filter(|&j| row[j] > 1)
+            .map(|j| skill_vertex(j, row[j]))
+            .collect::<Vec<usize>>();
+        psp.add_and_bonus_when_selected(&required, a[i], n_skill_vertices + i);
+    }
+
+    let (ans, _) = psp.solve();
+    io.writeln(ans);
+
+    io.flush();
+}

--- a/src/bin/atcoder/arc085_e_mul.rs
+++ b/src/bin/atcoder/arc085_e_mul.rs
@@ -1,0 +1,32 @@
+// AtCoder: ARC085-E - MUL
+// https://atcoder.jp/contests/arc085/tasks/arc085_c
+
+use anmitsu::graph::project_selection::ProjectSelection;
+use anmitsu::io::fastio::Fastio;
+
+fn main() {
+    let mut io = Fastio::new();
+
+    let n = io.u32() as usize;
+    let a = (0..n).map(|_| io.i64()).collect::<Vec<i64>>();
+
+    let mut psp = ProjectSelection::<i64>::new(n);
+    for (i, &ai) in a.iter().enumerate() {
+        psp.add_weight(i, ai);
+    }
+    for j in 2..=n {
+        for i in 1..j {
+            if j % i == 0 {
+                // 宝石 j (1-indexed) が生き残るなら、その約数 i も生き残って
+                // いなければならない (i を割る操作を行うと j も同時に割れて
+                // しまうため)。
+                psp.add_constraint(j - 1, i - 1);
+            }
+        }
+    }
+
+    let (ans, _) = psp.solve();
+    io.writeln(ans);
+
+    io.flush();
+}

--- a/src/bin/atcoder/practice2_d_maxflow.rs
+++ b/src/bin/atcoder/practice2_d_maxflow.rs
@@ -1,0 +1,82 @@
+// AtCoder: Library Practice Contest D - Maxflow
+// https://atcoder.jp/contests/practice2/tasks/practice2_d
+
+use anmitsu::graph::flow_graph::FlowGraph;
+use anmitsu::io::fastio::Fastio;
+
+fn main() {
+    let mut io = Fastio::new();
+
+    let n = io.u32() as usize;
+    let m = io.u32() as usize;
+
+    let grid = (0..n).map(|_| io.chars()).collect::<Vec<Vec<char>>>();
+    let cell_id = |i: usize, j: usize| i * m + j;
+    let source = n * m;
+    let sink = n * m + 1;
+
+    // 市松模様に2色 (黒: i+j が偶数, 白: i+j が奇数) へ塗り分けると、隣接する
+    // マスは必ず異なる色になる。黒マスを始点側、白マスを終点側とみなし、
+    // 隣接するマス同士に容量1の辺を張れば、ドミノを1枚も重ねずに敷き詰める
+    // 問題が、二部マッチング (最大流) に帰着できる。
+    let mut g = FlowGraph::<i64>::new(n * m + 2);
+
+    // ドミノの配置を復元できるよう、黒マスから白マスへの辺の番号と、両端の
+    // マスの座標を記録しておく。
+    let mut domino_edges = Vec::new();
+    for i in 0..n {
+        for j in 0..m {
+            if grid[i][j] == '#' {
+                continue;
+            }
+            if (i + j) % 2 == 0 {
+                g.add_edge(source, cell_id(i, j), 1);
+            } else {
+                g.add_edge(cell_id(i, j), sink, 1);
+            }
+            // 右隣・下隣のみを見ることで、隣接するマスの組をちょうど1回だけ
+            // 辺として張る。どちらの色が (i, j) 側かは色によって変わるため、
+            // 黒マス側から白マス側へ向くように毎回向きを決め直す。
+            for (ni, nj) in [(i, j + 1), (i + 1, j)] {
+                if ni < n && nj < m && grid[ni][nj] != '#' {
+                    let (black, white) = if (i + j) % 2 == 0 {
+                        (cell_id(i, j), cell_id(ni, nj))
+                    } else {
+                        (cell_id(ni, nj), cell_id(i, j))
+                    };
+                    let id = g.add_edge(black, white, 1);
+                    domino_edges.push((id, i, j, ni, nj));
+                }
+            }
+        }
+    }
+
+    let max_flow = g.max_flow(source, sink);
+
+    // 流量が1になった辺が、実際に置かれたドミノに対応する。
+    let mut output = grid;
+    for (id, i, j, ni, nj) in domino_edges {
+        let (_, _, _, flow) = g.get_edge(id);
+        if flow == 1 {
+            if ni == i {
+                // 横向きのドミノ: 左マスに '>'、右マスに '<' を置く。
+                output[i][j] = '>';
+                output[ni][nj] = '<';
+            } else {
+                // 縦向きのドミノ: 上マスに 'v'、下マスに '^' を置く。
+                output[i][j] = 'v';
+                output[ni][nj] = '^';
+            }
+        }
+    }
+
+    io.writeln(max_flow);
+    for row in output {
+        for ch in row {
+            io.write(ch);
+        }
+        io.write('\n');
+    }
+
+    io.flush();
+}

--- a/src/bin/atcoder/typical90_an_get_more_money.rs
+++ b/src/bin/atcoder/typical90_an_get_more_money.rs
@@ -1,0 +1,32 @@
+// AtCoder: Typical90 040 - Get More Money
+// https://atcoder.jp/contests/typical90/tasks/typical90_an
+
+use anmitsu::graph::project_selection::ProjectSelection;
+use anmitsu::io::fastio::Fastio;
+
+fn main() {
+    let mut io = Fastio::new();
+
+    let n = io.u32() as usize;
+    let w = io.i64();
+    let a = (0..n).map(|_| io.i64()).collect::<Vec<i64>>();
+
+    let mut psp = ProjectSelection::<i64>::new(n);
+    for (i, &ai) in a.iter().enumerate() {
+        // 家 i に入ると現金 ai を得るが、必ず料金 w を支払う。
+        psp.add_weight(i, ai - w);
+    }
+    for i in 0..n {
+        let k = io.u32() as usize;
+        for _ in 0..k {
+            let c = io.usize1();
+            // 家 c に入るには、家 c の鍵を持つ家 i にも入っていなければならない。
+            psp.add_constraint(c, i);
+        }
+    }
+
+    let (ans, _) = psp.solve();
+    io.writeln(ans);
+
+    io.flush();
+}

--- a/src/bin/codeforces/cf1082g_petya_and_graph.rs
+++ b/src/bin/codeforces/cf1082g_petya_and_graph.rs
@@ -1,0 +1,31 @@
+// Codeforces: 1082G - Petya and Graph
+// https://codeforces.com/problemset/problem/1082/G
+
+use anmitsu::graph::project_selection::ProjectSelection;
+use anmitsu::io::fastio::Fastio;
+
+fn main() {
+    let mut io = Fastio::new();
+
+    let n = io.u32() as usize;
+    let m = io.u32() as usize;
+    let a = (0..n).map(|_| io.i64()).collect::<Vec<i64>>();
+
+    let mut psp = ProjectSelection::<i64>::new(n + m);
+    for (i, &ai) in a.iter().enumerate() {
+        // 頂点 i を部分グラフに使うと、その分の重み ai を失う。
+        psp.add_weight(i, -ai);
+    }
+    for i in 0..m {
+        let u = io.usize1();
+        let v = io.usize1();
+        let w = io.i64();
+        // 辺 i は、両端点をともに部分グラフに使った場合にのみ、その重み w を得る。
+        psp.add_and_bonus_when_selected(&[u, v], w, n + i);
+    }
+
+    let (ans, _) = psp.solve();
+    io.writeln(ans);
+
+    io.flush();
+}

--- a/src/bin/library_checker/assignment.rs
+++ b/src/bin/library_checker/assignment.rs
@@ -1,0 +1,57 @@
+// Library Checker: Assignment Problem
+// https://judge.yosupo.jp/problem/assignment
+
+use anmitsu::graph::min_cost_flow_graph::MinCostFlowGraph;
+use anmitsu::io::fastio::Fastio;
+
+fn main() {
+    let mut io = Fastio::new();
+
+    let n = io.u32() as usize;
+    let a = (0..n)
+        .map(|_| (0..n).map(|_| io.i64()).collect::<Vec<i64>>())
+        .collect::<Vec<Vec<i64>>>();
+
+    // 行 i を左側の頂点、列 j を右側の頂点とする完全二部グラフを作り、
+    // 各行から各列への辺にコスト a[i][j] を持たせる。すべての行・列を
+    // ちょうど1回ずつ使う割り当ては、始点から終点への流量 n の最小費用流に
+    // 一致する。
+    let source = 0;
+    let left = |i: usize| 1 + i;
+    let right = |j: usize| 1 + n + j;
+    let sink = 1 + 2 * n;
+
+    let mut g = MinCostFlowGraph::<i64>::new(2 + 2 * n);
+    for i in 0..n {
+        g.add_edge(source, left(i), 1, 0);
+    }
+    for j in 0..n {
+        g.add_edge(right(j), sink, 1, 0);
+    }
+    let edge_id = (0..n)
+        .map(|i| {
+            (0..n)
+                .map(|j| g.add_edge(left(i), right(j), 1, a[i][j]))
+                .collect::<Vec<usize>>()
+        })
+        .collect::<Vec<Vec<usize>>>();
+
+    let (_, cost) = g.min_cost_flow(source, sink);
+
+    // 各行がちょうど1本、流量1の辺を持つはずであり、それが割り当てられた
+    // 列にあたる。
+    let assignment = (0..n)
+        .map(|i| {
+            (0..n)
+                .find(|&j| g.get_edge(edge_id[i][j]).4 == 1)
+                .expect("each row must be assigned to exactly one column")
+        })
+        .collect::<Vec<usize>>();
+
+    io.writeln(cost);
+    for p in assignment {
+        io.writeln(p as u32);
+    }
+
+    io.flush();
+}

--- a/src/bin/poj/poj2987_firing.rs
+++ b/src/bin/poj/poj2987_firing.rs
@@ -1,0 +1,49 @@
+// POJ: 2987 - Firing
+// http://poj.org/problem?id=2987
+
+use anmitsu::graph::project_selection::ProjectSelection;
+use anmitsu::io::fastio::Fastio;
+
+// Fastio の数値書き込みは write/writeln のどちらを使っても改行文字まで出力してしまうため、
+// この問題のように「人数と利益を同じ行に並べる」形式には使えない。
+// char の書き込みだけは改行を伴わないため、あらかじめ文字列化したトークン列を
+// 1文字ずつ書き込むことで、任意の内容を1行にまとめて出力する。
+fn write_line(io: &mut Fastio, tokens: &[String]) {
+    for (i, token) in tokens.iter().enumerate() {
+        if i > 0 {
+            io.write(' ');
+        }
+        for c in token.chars() {
+            io.write(c);
+        }
+    }
+    io.write('\n');
+}
+
+fn main() {
+    let mut io = Fastio::new();
+
+    let n = io.u32() as usize;
+    let m = io.u32() as usize;
+
+    let mut psp = ProjectSelection::<i64>::new(n);
+    for i in 0..n {
+        let b = io.i64();
+        // 従業員 i を解雇すると、その分の損得 b を得る。
+        psp.add_weight(i, b);
+    }
+    for _ in 0..m {
+        let boss = io.usize1();
+        let underling = io.usize1();
+        // 上司を解雇するなら、その部下も解雇しなければならない。
+        psp.add_constraint(boss, underling);
+    }
+
+    let (profit, fired) = psp.solve();
+    // 最小カットの S 側 (始点から到達できる側) は、最適値を達成する解雇者集合の
+    // うち包含関係で最小のものと一致するため、解雇人数も追加の計算なしに求まる。
+    let count = fired.iter().filter(|&&is_fired| is_fired).count();
+    write_line(&mut io, &[count.to_string(), profit.to_string()]);
+
+    io.flush();
+}

--- a/src/bin/yukicoder/yuki2713_just_solitaire.rs
+++ b/src/bin/yukicoder/yuki2713_just_solitaire.rs
@@ -1,0 +1,31 @@
+// yukicoder: No.2713 Just Solitaire
+// https://yukicoder.me/problems/no/2713
+
+use anmitsu::graph::project_selection::ProjectSelection;
+use anmitsu::io::fastio::Fastio;
+
+fn main() {
+    let mut io = Fastio::new();
+
+    let n = io.u32() as usize;
+    let m = io.u32() as usize;
+    let a = (0..n).map(|_| io.i64()).collect::<Vec<i64>>();
+    let b = (0..m).map(|_| io.i64()).collect::<Vec<i64>>();
+
+    let mut psp = ProjectSelection::<i64>::new(n + m);
+    for (i, &ai) in a.iter().enumerate() {
+        // カード i を使うと、その分のお金 ai を消費する。
+        psp.add_weight(i, -ai);
+    }
+    for (i, &bi) in b.iter().enumerate() {
+        let k = io.u32() as usize;
+        let cards = (0..k).map(|_| io.usize1()).collect::<Vec<usize>>();
+        // ボーナス i は、指定されたカードをすべて使った場合にのみ得られる。
+        psp.add_and_bonus_when_selected(&cards, bi, n + i);
+    }
+
+    let (ans, _) = psp.solve();
+    io.writeln(ans);
+
+    io.flush();
+}

--- a/src/graph/flow_graph.rs
+++ b/src/graph/flow_graph.rs
@@ -1,0 +1,272 @@
+//! 最大流問題・最小費用流問題で共通して使う、残余グラフの土台を提供する
+//! モジュールである。
+//!
+//! [`Graph<T>`](super::graph::Graph) とは別の専用構造を用いる。増加パス探索
+//! (Dinic 法・Bellman-Ford 法など) では、ある辺の残余容量を増減させた際に、
+//! その逆辺の残余容量も同時に更新する必要がある。そこで、各辺に逆辺への
+//! インデックスを直接持たせることで、逆辺を O(1) で参照・更新できるようにする。
+
+use std::ops;
+
+/// フロー問題における容量として利用可能な数値型が満たすべき制約をまとめた
+/// trait である。
+///
+/// 残余容量の初期化に単位元 (`ZERO`) が、増加パスの探索の初期値に十分大きな
+/// 上界 (`MAX`) が必要となるため、通常の数値演算に加えてこれらを定数として
+/// 要求する。
+pub trait FlowCapacity: Copy + Ord + ops::Add<Output = Self> + ops::Sub<Output = Self> {
+    /// 加法の単位元 (0)。
+    const ZERO: Self;
+    /// この型が表現できる最大値。増加パス探索の初期上界として使う。
+    const MAX: Self;
+}
+
+macro_rules! impl_flow_capacity {
+    ($($t:ty),*) => {
+        $(
+            impl FlowCapacity for $t {
+                const ZERO: Self = 0;
+                const MAX: Self = <$t>::MAX;
+            }
+        )*
+    };
+}
+impl_flow_capacity!(i32, i64, u32, u64);
+
+/// 残余グラフ上の1本の有向辺を表す。
+pub(super) struct ResidualEdge<Cap> {
+    /// 辺の終点。
+    pub(super) to: usize,
+    /// 残余容量。
+    pub(super) cap: Cap,
+    /// 逆辺 (終点側の隣接リストに張られている、この辺に対応する辺) の、
+    /// 隣接リスト内でのインデックス。
+    pub(super) rev: usize,
+}
+
+/// 最大流問題・最小費用流問題を表現する有向グラフ。各辺には非負の容量を持たせる。
+pub struct FlowGraph<Cap> {
+    /// `graph[u]` は、頂点 `u` から出る残余辺の並びである。各辺を追加した際、
+    /// 対応する逆辺 (残余容量0で初期化) も終点側に同時に追加される。
+    pub(super) graph: Vec<Vec<ResidualEdge<Cap>>>,
+    /// `pos[i]` は、`i` 番目に追加した辺の `(始点, 始点の隣接リスト内での添字)`
+    /// の組である。追加後の残余容量や流量を、辺番号から引けるようにするために
+    /// 使う。
+    pos: Vec<(usize, usize)>,
+}
+
+impl<Cap> FlowGraph<Cap> {
+    /// `n` 頂点、辺を持たないフローグラフを生成する。
+    ///
+    /// # Args
+    /// - `n`: 頂点数。
+    ///
+    /// # Returns
+    /// `Self`: 頂点数 `n`、辺を持たない `FlowGraph<Cap>`。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(n)
+    /// - 空間計算量: O(n)
+    #[must_use]
+    pub fn new(n: usize) -> Self {
+        FlowGraph {
+            graph: (0..n).map(|_| Vec::new()).collect::<Vec<_>>(),
+            pos: Vec::new(),
+        }
+    }
+
+    /// グラフの頂点数を返す。
+    ///
+    /// # Returns
+    /// `usize`: 頂点数。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(1)
+    pub fn vertex_count(&self) -> usize {
+        self.graph.len()
+    }
+
+    /// これまでに追加した辺の本数を返す。
+    ///
+    /// # Returns
+    /// `usize`: 追加した辺の本数。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(1)
+    pub fn edge_count(&self) -> usize {
+        self.pos.len()
+    }
+}
+
+impl<Cap: FlowCapacity> FlowGraph<Cap> {
+    /// 容量 `cap` の有向辺 `from -> to` を追加し、辺番号を返す。
+    ///
+    /// 内部では、残余容量 `cap` を持つ順辺に加え、残余容量0の逆辺を同時に
+    /// 張る。逆辺の残余容量は、流量が押し出されるたびに増加していく。
+    ///
+    /// # Args
+    /// - `from`: 辺の始点。`0..vertex_count()` の範囲でなければならない。
+    /// - `to`: 辺の終点。`0..vertex_count()` の範囲でなければならない。
+    /// - `cap`: 辺の容量。非負でなければならない。
+    ///
+    /// # Returns
+    /// `usize`: 追加した辺の番号。[`get_edge`](Self::get_edge) で参照する際に
+    /// 使う。
+    ///
+    /// # Panics
+    /// - `from`/`to` が `0..vertex_count()` の範囲外の場合にパニックする。
+    ///
+    /// # Complexity
+    /// - 時間計算量: 償却 O(1)
+    ///
+    /// # Examples
+    /// ```
+    /// use anmitsu::graph::flow_graph::FlowGraph;
+    ///
+    /// let mut g = FlowGraph::<i64>::new(2);
+    /// let id = g.add_edge(0, 1, 5);
+    /// assert_eq!((0, 1, 5, 0), g.get_edge(id));
+    /// ```
+    pub fn add_edge(&mut self, from: usize, to: usize, cap: Cap) -> usize {
+        let id = self.edge_count();
+
+        // 自己ループ (from == to) の場合、順辺と逆辺が同じ頂点の隣接リストへ
+        // 追加されるため、逆辺のインデックスは「追加前の長さ + 1」になる。
+        // 自己ループでない場合は、それぞれ別の隣接リストへの追加になるため、
+        // 単純に「追加前の長さ」がそのまま自分の (相手から見た) インデックスになる。
+        let from_index = self.graph[from].len();
+        let to_index = self.graph[to].len() + usize::from(from == to);
+
+        self.pos.push((from, from_index));
+        self.graph[from].push(ResidualEdge {
+            to,
+            cap,
+            rev: to_index,
+        });
+        self.graph[to].push(ResidualEdge {
+            to: from,
+            cap: Cap::ZERO,
+            rev: from_index,
+        });
+
+        id
+    }
+
+    /// `i` 番目に追加した辺の `(始点, 終点, 元の容量, 現在の流量)` を返す。
+    ///
+    /// 元の容量は、順辺の残余容量と逆辺の残余容量の和として求まる。両者の和は
+    /// 流量の増減によらず常に元の容量に保たれるからである。また、逆辺の残余
+    /// 容量は0から始まり流量が押し出されるたびに増加するため、そのままこの辺の
+    /// 現在の流量に等しい。
+    ///
+    /// # Args
+    /// - `i`: 辺番号。[`add_edge`](Self::add_edge) の戻り値。
+    ///
+    /// # Returns
+    /// `(usize, usize, Cap, Cap)`: `(始点, 終点, 元の容量, 現在の流量)`。
+    ///
+    /// # Panics
+    /// - `i` が `0..edge_count()` の範囲外の場合にパニックする。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(1)
+    pub fn get_edge(&self, i: usize) -> (usize, usize, Cap, Cap) {
+        let (from, index) = self.pos[i];
+        let edge = &self.graph[from][index];
+        let reverse = &self.graph[edge.to][edge.rev];
+        (from, edge.to, edge.cap + reverse.cap, reverse.cap)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // new のテスト: 生成直後の状態を検証する。
+    mod new {
+        use super::*;
+
+        /// Scenario: 生成直後のフローグラフは、指定した頂点数を持ち、辺を
+        /// 持たない。
+        /// - Given: 頂点数 3 を指定する。
+        /// - When: `FlowGraph::new(3)` を呼ぶ。
+        /// - Then: `vertex_count()` が 3 を返し、`edge_count()` が 0 を返す。
+        #[test]
+        fn creates_graph_with_given_vertex_count_and_no_edges() {
+            // Given, When
+            let sut = FlowGraph::<i64>::new(3);
+            // Then
+            assert_eq!(3, sut.vertex_count());
+            assert_eq!(0, sut.edge_count());
+        }
+    }
+
+    // add_edge のテスト: 呼び出し後の状態変化 (get_edge で観測できる内容) を
+    // 検証する。
+    mod add_edge {
+        use super::*;
+
+        /// Scenario: 辺を追加すると、流量0の状態で観測できる。
+        /// - Given: 2頂点、辺を持たないフローグラフがある。
+        /// - When: `0 -> 1` に容量5の辺を追加する。
+        /// - Then: `get_edge` で `(0, 1, 5, 0)` が観測できる。
+        #[test]
+        fn records_edge_with_zero_flow() {
+            // Given
+            let mut sut = FlowGraph::<i64>::new(2);
+            // When
+            let id = sut.add_edge(0, 1, 5);
+            // Then
+            assert_eq!((0, 1, 5, 0), sut.get_edge(id));
+        }
+
+        /// Scenario: 辺番号は追加した順に0から振られる。
+        /// - Given: 3頂点、辺を持たないフローグラフがある。
+        /// - When: 辺を2本追加する。
+        /// - Then: 辺番号はそれぞれ0, 1になり、`edge_count()` は2になる。
+        #[test]
+        fn assigns_sequential_ids_in_insertion_order() {
+            // Given
+            let mut sut = FlowGraph::<i64>::new(3);
+            // When
+            let id0 = sut.add_edge(0, 1, 1);
+            let id1 = sut.add_edge(1, 2, 1);
+            // Then
+            assert_eq!(0, id0);
+            assert_eq!(1, id1);
+            assert_eq!(2, sut.edge_count());
+        }
+
+        /// Scenario: 自己ループを追加しても、逆辺の対応関係が壊れない
+        /// (境界値)。
+        /// - Given: 1頂点、辺を持たないフローグラフがある。
+        /// - When: `0 -> 0` に容量3の自己ループを追加する。
+        /// - Then: `get_edge` で `(0, 0, 3, 0)` が観測できる。
+        #[test]
+        fn keeps_reverse_edge_consistent_for_self_loop() {
+            // Given
+            let mut sut = FlowGraph::<i64>::new(1);
+            // When
+            let id = sut.add_edge(0, 0, 3);
+            // Then
+            assert_eq!((0, 0, 3, 0), sut.get_edge(id));
+        }
+
+        /// Scenario: 同じ2頂点間に複数の辺 (多重辺) を追加しても、それぞれが
+        /// 独立に観測できる。
+        /// - Given: 2頂点、辺を持たないフローグラフがある。
+        /// - When: `0 -> 1` に容量の異なる辺を2本追加する。
+        /// - Then: それぞれの辺を個別の辺番号で観測できる。
+        #[test]
+        fn allows_multi_edge() {
+            // Given
+            let mut sut = FlowGraph::<i64>::new(2);
+            // When
+            let id0 = sut.add_edge(0, 1, 2);
+            let id1 = sut.add_edge(0, 1, 7);
+            // Then
+            assert_eq!((0, 1, 2, 0), sut.get_edge(id0));
+            assert_eq!((0, 1, 7, 0), sut.get_edge(id1));
+        }
+    }
+}

--- a/src/graph/flow_graph.rs
+++ b/src/graph/flow_graph.rs
@@ -59,10 +59,10 @@ impl<Cap> FlowGraph<Cap> {
     /// `n` 頂点、辺を持たないフローグラフを生成する。
     ///
     /// # Args
-    /// - `n`: 頂点数。
+    /// - `n`: 頂点数
     ///
     /// # Returns
-    /// `Self`: 頂点数 `n`、辺を持たない `FlowGraph<Cap>`。
+    /// `Self`: 頂点数 `n`、辺を持たない `FlowGraph<Cap>`
     ///
     /// # Complexity
     /// - 時間計算量: O(n)
@@ -78,7 +78,7 @@ impl<Cap> FlowGraph<Cap> {
     /// グラフの頂点数を返す。
     ///
     /// # Returns
-    /// `usize`: 頂点数。
+    /// `usize`: 頂点数
     ///
     /// # Complexity
     /// - 時間計算量: O(1)
@@ -89,7 +89,7 @@ impl<Cap> FlowGraph<Cap> {
     /// これまでに追加した辺の本数を返す。
     ///
     /// # Returns
-    /// `usize`: 追加した辺の本数。
+    /// `usize`: 追加した辺の本数
     ///
     /// # Complexity
     /// - 時間計算量: O(1)
@@ -105,13 +105,13 @@ impl<Cap: FlowCapacity> FlowGraph<Cap> {
     /// 張る。逆辺の残余容量は、流量が押し出されるたびに増加していく。
     ///
     /// # Args
-    /// - `from`: 辺の始点。`0..vertex_count()` の範囲でなければならない。
-    /// - `to`: 辺の終点。`0..vertex_count()` の範囲でなければならない。
-    /// - `cap`: 辺の容量。非負でなければならない。
+    /// - `from`: 辺の始点であり、`0..vertex_count()` の範囲でなければならない。
+    /// - `to`: 辺の終点であり、`0..vertex_count()` の範囲でなければならない。
+    /// - `cap`: 辺の容量であり、非負でなければならない。
     ///
     /// # Returns
-    /// `usize`: 追加した辺の番号。[`get_edge`](Self::get_edge) で参照する際に
-    /// 使う。
+    /// `usize`: 追加した辺の番号であり、[`get_edge`](Self::get_edge) で参照する
+    /// 際に使う。
     ///
     /// # Panics
     /// - `from`/`to` が `0..vertex_count()` の範囲外の場合にパニックする。
@@ -160,10 +160,10 @@ impl<Cap: FlowCapacity> FlowGraph<Cap> {
     /// 現在の流量に等しい。
     ///
     /// # Args
-    /// - `i`: 辺番号。[`add_edge`](Self::add_edge) の戻り値。
+    /// - `i`: 辺番号であり、[`add_edge`](Self::add_edge) の戻り値である。
     ///
     /// # Returns
-    /// `(usize, usize, Cap, Cap)`: `(始点, 終点, 元の容量, 現在の流量)`。
+    /// `(usize, usize, Cap, Cap)`: `(始点, 終点, 元の容量, 現在の流量)`
     ///
     /// # Panics
     /// - `i` が `0..edge_count()` の範囲外の場合にパニックする。

--- a/src/graph/max_flow.rs
+++ b/src/graph/max_flow.rs
@@ -117,10 +117,14 @@ impl<Cap: flow_graph::FlowCapacity> FlowGraph<Cap> {
         let mut visited = vec![false; n];
         visited[s] = true;
 
+        // s を起点に、残余容量が正の辺のみを辿って幅優先探索を行う。訪問できた
+        // 頂点が、最小カットの s 側に属する頂点である。
         let mut queue = collections::VecDeque::new();
         queue.push_back(s);
         while let Some(u) = queue.pop_front() {
             for edge in &self.graph[u] {
+                // 残余容量が正の辺だけを辿り、まだ訪問していない頂点だけを
+                // 新たに訪問済みにする。
                 if edge.cap > Cap::ZERO && !visited[edge.to] {
                     visited[edge.to] = true;
                     queue.push_back(edge.to);
@@ -148,10 +152,14 @@ impl<Cap: flow_graph::FlowCapacity> FlowGraph<Cap> {
         let mut level = vec![None; n];
         level[s] = Some(0);
 
+        // キューから頂点を1つずつ取り出し、そこから残余容量が正の辺を1本
+        // 辿った先の頂点へレベルを伝播させていく (幅優先探索)。
         let mut queue = collections::VecDeque::new();
         queue.push_back(s);
         while let Some(u) = queue.pop_front() {
             for edge in &self.graph[u] {
+                // 残余容量が正の辺のみを辿り、まだレベルが決まっていない頂点
+                // だけを、u のレベルより1つ大きいレベルとして確定させる。
                 if edge.cap > Cap::ZERO && level[edge.to].is_none() {
                     level[edge.to] = Some(level[u].unwrap() + 1);
                     queue.push_back(edge.to);

--- a/src/graph/max_flow.rs
+++ b/src/graph/max_flow.rs
@@ -23,12 +23,12 @@ impl<Cap: flow_graph::FlowCapacity> FlowGraph<Cap> {
     /// [`min_cut`](Self::min_cut) でそれぞれ参照できる。
     ///
     /// # Args
-    /// - `s`: 始点。`0..vertex_count()` の範囲でなければならない。
-    /// - `t`: 終点。`0..vertex_count()` の範囲でなければならず、`s` と異なって
-    ///   いなければならない。
+    /// - `s`: 始点であり、`0..vertex_count()` の範囲でなければならない。
+    /// - `t`: 終点であり、`0..vertex_count()` の範囲でなければならず、`s` と
+    ///   異なっていなければならない。
     ///
     /// # Returns
-    /// `Cap`: `s` から `t` への最大流量。
+    /// `Cap`: `s` から `t` への最大流量
     ///
     /// # Panics
     /// - `s == t` の場合にパニックする。
@@ -135,11 +135,11 @@ impl<Cap: flow_graph::FlowCapacity> FlowGraph<Cap> {
     /// (最短距離) を求める。
     ///
     /// # Args
-    /// - `s`: 始点。
+    /// - `s`: 始点
     ///
     /// # Returns
     /// `Vec<Option<usize>>`: `result[v]` は `s` から `v` への残余グラフ上の
-    /// 最短距離。到達できない場合は `None`。
+    /// 最短距離であり、到達できない場合は `None` である。
     ///
     /// # Complexity
     /// - 時間計算量: O(V + E)
@@ -171,15 +171,15 @@ impl<Cap: flow_graph::FlowCapacity> FlowGraph<Cap> {
     /// 行き止まりと分かった辺を二度と辿らない。
     ///
     /// # Args
-    /// - `s`: 始点。
-    /// - `t`: 終点。
-    /// - `level`: [`bfs_levels`](Self::bfs_levels) が返したレベル。
-    /// - `iter`: 頂点ごとの「現在辺」ポインタ。同じフェーズの間、呼び出し元で
-    ///   使い回す。
+    /// - `s`: 始点
+    /// - `t`: 終点
+    /// - `level`: [`bfs_levels`](Self::bfs_levels) が返したレベル
+    /// - `iter`: 頂点ごとの「現在辺」ポインタであり、同じフェーズの間、
+    ///   呼び出し元で使い回す。
     ///
     /// # Returns
-    /// `Cap`: 見つけた増加パスに流した量。増加パスが見つからなかった場合は
-    /// `Cap::ZERO`。
+    /// `Cap`: 見つけた増加パスに流した量であり、増加パスが見つからなかった
+    /// 場合は `Cap::ZERO` である。
     ///
     /// # Complexity
     /// - 時間計算量: 償却 O(V + E) (`iter` を同一フェーズ内で使い回すため)

--- a/src/graph/max_flow.rs
+++ b/src/graph/max_flow.rs
@@ -1,0 +1,399 @@
+//! Dinic 法による最大流の計算を提供するモジュールである。
+//!
+//! 各フェーズで、始点からの BFS 距離 (レベル) をもとに、レベルが単調増加する
+//! 辺のみからなる「レベルグラフ」を構成し、そのグラフ上で飽和するまで
+//! (増加パスが尽きるまで) フローを流す「ブロッキングフロー」を1回求める。
+//! これを、始点から終点へ到達できなくなるまで繰り返す。ブロッキングフローの
+//! 探索では、各頂点で「次に試す辺」を指すポインタ (`iter`) を使い回すことで、
+//! 同じフェーズ内で無駄な辺の再訪問を避ける (この最適化により、1フェーズあたり
+//! O(VE) で抑えられる)。
+//!
+//! 深さ優先探索は、頂点数が大きい場合の再帰によるスタックオーバーフローを
+//! 避けるため、明示的なスタックを使って反復的に行う。
+
+use std::collections;
+
+use super::flow_graph::{self, FlowGraph};
+
+impl<Cap: flow_graph::FlowCapacity> FlowGraph<Cap> {
+    /// Dinic 法により、頂点 `s` から頂点 `t` への最大流量を求める。
+    ///
+    /// 呼び出し後、内部の残余容量は最大流を実現した状態に更新されている。
+    /// 各辺の流量は [`get_edge`](Self::get_edge) で、最小カットは
+    /// [`min_cut`](Self::min_cut) でそれぞれ参照できる。
+    ///
+    /// # Args
+    /// - `s`: 始点。`0..vertex_count()` の範囲でなければならない。
+    /// - `t`: 終点。`0..vertex_count()` の範囲でなければならず、`s` と異なって
+    ///   いなければならない。
+    ///
+    /// # Returns
+    /// `Cap`: `s` から `t` への最大流量。
+    ///
+    /// # Panics
+    /// - `s == t` の場合にパニックする。
+    /// - `s`/`t` が `0..vertex_count()` の範囲外の場合にパニックする。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(V^2 E)
+    ///   - V は頂点数、E は辺数である。単位容量に近いグラフではより高速に
+    ///     動作する (例えば二部マッチングに相当する構成では O(E sqrt(V)))。
+    /// - 空間計算量: O(V)
+    ///
+    /// # Examples
+    /// ```
+    /// use anmitsu::graph::flow_graph::FlowGraph;
+    ///
+    /// // 0 -> 1 -> 3, 0 -> 2 -> 3 の2つの経路 (各辺容量2) を持つグラフ。
+    /// let mut g = FlowGraph::<i64>::new(4);
+    /// g.add_edge(0, 1, 2);
+    /// g.add_edge(0, 2, 2);
+    /// g.add_edge(1, 3, 2);
+    /// g.add_edge(2, 3, 2);
+    ///
+    /// assert_eq!(4, g.max_flow(0, 3));
+    /// ```
+    pub fn max_flow(&mut self, s: usize, t: usize) -> Cap {
+        debug_assert!(s != t, "s and t must be different vertices");
+
+        let n = self.vertex_count();
+        let mut flow = Cap::ZERO;
+
+        loop {
+            let level = self.bfs_levels(s);
+            // 終点に到達できなくなった時点で、これ以上増加パスは存在しない。
+            if level[t].is_none() {
+                break;
+            }
+
+            // 「現在辺」ポインタ。同じフェーズ (レベルグラフ) の間、頂点ごとに
+            // 使い回すことで、探索済みで行き止まりと分かった辺を再訪問しない
+            // ようにする。
+            let mut iter = vec![0_usize; n];
+            loop {
+                let pushed = self.dfs_augmenting_path(s, t, &level, &mut iter);
+                if pushed == Cap::ZERO {
+                    break;
+                }
+                flow = flow + pushed;
+            }
+        }
+
+        flow
+    }
+
+    /// 最大流を求めた後の残余グラフにおいて、頂点 `s` から到達可能な頂点の
+    /// 集合を返す。これは `s` を含む側の最小カットに一致する。
+    ///
+    /// # Args
+    /// - `s`: [`max_flow`](Self::max_flow) を呼んだ際に指定した始点と同じ
+    ///   頂点を渡す。
+    ///
+    /// # Returns
+    /// `Vec<bool>`: `result[v]` が `true` であれば、頂点 `v` は最小カットの
+    /// `s` 側に属する。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(V + E)
+    ///
+    /// # Examples
+    /// ```
+    /// use anmitsu::graph::flow_graph::FlowGraph;
+    ///
+    /// let mut g = FlowGraph::<i64>::new(3);
+    /// g.add_edge(0, 1, 3);
+    /// g.add_edge(1, 2, 1);
+    ///
+    /// assert_eq!(1, g.max_flow(0, 2));
+    /// let cut = g.min_cut(0);
+    /// // 0->1 はまだ残余容量があるため 1 も s 側に含まれるが、1->2 が
+    /// // 飽和しているため 2 には到達できない。
+    /// assert!(cut[0]);
+    /// assert!(cut[1]);
+    /// assert!(!cut[2]);
+    /// ```
+    pub fn min_cut(&self, s: usize) -> Vec<bool> {
+        let n = self.vertex_count();
+        let mut visited = vec![false; n];
+        visited[s] = true;
+
+        let mut queue = collections::VecDeque::new();
+        queue.push_back(s);
+        while let Some(u) = queue.pop_front() {
+            for edge in &self.graph[u] {
+                if edge.cap > Cap::ZERO && !visited[edge.to] {
+                    visited[edge.to] = true;
+                    queue.push_back(edge.to);
+                }
+            }
+        }
+
+        visited
+    }
+
+    /// 始点 `s` からの BFS により、残余容量が正の辺のみを辿ってレベル
+    /// (最短距離) を求める。
+    ///
+    /// # Args
+    /// - `s`: 始点。
+    ///
+    /// # Returns
+    /// `Vec<Option<usize>>`: `result[v]` は `s` から `v` への残余グラフ上の
+    /// 最短距離。到達できない場合は `None`。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(V + E)
+    fn bfs_levels(&self, s: usize) -> Vec<Option<usize>> {
+        let n = self.vertex_count();
+        let mut level = vec![None; n];
+        level[s] = Some(0);
+
+        let mut queue = collections::VecDeque::new();
+        queue.push_back(s);
+        while let Some(u) = queue.pop_front() {
+            for edge in &self.graph[u] {
+                if edge.cap > Cap::ZERO && level[edge.to].is_none() {
+                    level[edge.to] = Some(level[u].unwrap() + 1);
+                    queue.push_back(edge.to);
+                }
+            }
+        }
+
+        level
+    }
+
+    /// レベルグラフ上で、`s` から `t` への増加パスを1本探し、その最大流量
+    /// (ボトルネック) だけ流す。
+    ///
+    /// 明示的なスタックで `s` からの経路を管理する。ある頂点で使える辺が
+    /// 尽きたら (行き止まりなら) その頂点をスタックから外し、1つ前の頂点の
+    /// 「現在辺」ポインタを進める。これにより、同じフェーズ内では、一度
+    /// 行き止まりと分かった辺を二度と辿らない。
+    ///
+    /// # Args
+    /// - `s`: 始点。
+    /// - `t`: 終点。
+    /// - `level`: [`bfs_levels`](Self::bfs_levels) が返したレベル。
+    /// - `iter`: 頂点ごとの「現在辺」ポインタ。同じフェーズの間、呼び出し元で
+    ///   使い回す。
+    ///
+    /// # Returns
+    /// `Cap`: 見つけた増加パスに流した量。増加パスが見つからなかった場合は
+    /// `Cap::ZERO`。
+    ///
+    /// # Complexity
+    /// - 時間計算量: 償却 O(V + E) (`iter` を同一フェーズ内で使い回すため)
+    fn dfs_augmenting_path(
+        &mut self,
+        s: usize,
+        t: usize,
+        level: &[Option<usize>],
+        iter: &mut [usize],
+    ) -> Cap {
+        // s から t への経路を、頂点ではなく「その頂点から次へ進んだ際に
+        // 使った辺のインデックス」の列として記録する。ボトルネックの計算と
+        // 流量の反映の両方で、辺そのものへ直接アクセスする必要があるためである。
+        let mut path = Vec::new();
+        let mut u = s;
+
+        while u != t {
+            let mut advanced = false;
+            while iter[u] < self.graph[u].len() {
+                let edge = &self.graph[u][iter[u]];
+                let can_advance =
+                    edge.cap > Cap::ZERO && level[edge.to] == level[u].map(|lv| lv + 1);
+                if can_advance {
+                    path.push((u, iter[u]));
+                    u = edge.to;
+                    advanced = true;
+                    break;
+                }
+                iter[u] += 1;
+            }
+
+            if !advanced {
+                // u から先へは進めない (行き止まり) ため、経路を1つ戻す。
+                // s 自体が行き止まりであれば、このフェーズに増加パスは
+                // もう存在しない。
+                let Some(&(parent, _)) = path.last() else {
+                    return Cap::ZERO;
+                };
+                path.pop();
+                // 戻った先の頂点から見て、u へ向かう辺はもう使えないと
+                // 分かったため、次に試す辺へ進める。
+                iter[parent] += 1;
+                u = parent;
+            }
+        }
+
+        // 経路上の各辺の残余容量のうち最小のものが、流せる量 (ボトルネック)
+        // になる。
+        let bottleneck = path
+            .iter()
+            .map(|&(v, idx)| self.graph[v][idx].cap)
+            .min()
+            .unwrap_or(Cap::MAX);
+
+        for (v, idx) in path {
+            let edge_to = self.graph[v][idx].to;
+            let edge_rev = self.graph[v][idx].rev;
+            self.graph[v][idx].cap = self.graph[v][idx].cap - bottleneck;
+            self.graph[edge_to][edge_rev].cap = self.graph[edge_to][edge_rev].cap + bottleneck;
+        }
+
+        bottleneck
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // max_flow のテスト: 戻り値そのものと、呼び出し後に get_edge で観測できる
+    // 各辺の流量を検証する。
+    mod max_flow {
+        use super::*;
+
+        /// Scenario: 単純な直列経路では、最も細い辺の容量が最大流になる。
+        /// - Given: `0 -> 1 -> 2` (容量 3, 1) の経路がある。
+        /// - When: 0 から 2 への最大流を求める。
+        /// - Then: 最大流は 1 (最も細い辺の容量) になる。
+        #[test]
+        fn bottlenecked_by_thinnest_edge_in_series() {
+            // Given
+            let mut sut = FlowGraph::<i64>::new(3);
+            sut.add_edge(0, 1, 3);
+            sut.add_edge(1, 2, 1);
+            // When
+            let result = sut.max_flow(0, 2);
+            // Then
+            assert_eq!(1, result);
+        }
+
+        /// Scenario: 並列な複数経路の容量は加算される。
+        /// - Given: `0 -> 1 -> 3` と `0 -> 2 -> 3` (各辺容量2) の、独立した
+        ///   2経路がある。
+        /// - When: 0 から 3 への最大流を求める。
+        /// - Then: 最大流は 4 (2経路の容量の和) になる。
+        #[test]
+        fn sums_capacities_of_independent_parallel_paths() {
+            // Given
+            let mut sut = FlowGraph::<i64>::new(4);
+            sut.add_edge(0, 1, 2);
+            sut.add_edge(0, 2, 2);
+            sut.add_edge(1, 3, 2);
+            sut.add_edge(2, 3, 2);
+            // When
+            let result = sut.max_flow(0, 3);
+            // Then
+            assert_eq!(4, result);
+        }
+
+        /// Scenario: 終点に到達できないグラフでは、最大流は0になる (境界値)。
+        /// - Given: 0 から 1 への辺を持たない、孤立した頂点を含むグラフが
+        ///   ある。
+        /// - When: 0 から 1 への最大流を求める。
+        /// - Then: 最大流は0になる。
+        #[test]
+        fn returns_zero_when_sink_is_unreachable() {
+            // Given
+            let mut sut = FlowGraph::<i64>::new(2);
+            // When
+            let result = sut.max_flow(0, 1);
+            // Then
+            assert_eq!(0, result);
+        }
+
+        /// Scenario: 中継点の容量が両側の辺より小さい場合、それがボトル
+        /// ネックになる (逆辺を使わないと最大流に到達できない典型例)。
+        /// - Given: `0 -> 1` (容量3), `1 -> 2` (容量1), `1 -> 3` (容量3),
+        ///   `2 -> 3` (容量3) を持つグラフがある。
+        /// - When: 0 から 3 への最大流を求める。
+        /// - Then: 最大流は 3 (`0->1` と `1->3` の容量) になる。
+        #[test]
+        fn handles_diamond_shaped_graph_correctly() {
+            // Given
+            let mut sut = FlowGraph::<i64>::new(4);
+            sut.add_edge(0, 1, 3);
+            sut.add_edge(1, 2, 1);
+            sut.add_edge(1, 3, 3);
+            sut.add_edge(2, 3, 3);
+            // When
+            let result = sut.max_flow(0, 3);
+            // Then
+            assert_eq!(3, result);
+        }
+
+        /// Scenario: 呼び出し後、各辺の流量を get_edge で参照できる。
+        /// - Given: `0 -> 1 -> 2` (容量5, 3) の経路がある。
+        /// - When: 0 から 2 への最大流を求める。
+        /// - Then: `0->1` の流量は3 (ボトルネック分のみ使われる) になり、
+        ///   `1->2` の流量は3 (容量いっぱい) になる。
+        #[test]
+        fn exposes_flow_per_edge_via_get_edge() {
+            // Given
+            let mut sut = FlowGraph::<i64>::new(3);
+            let e01 = sut.add_edge(0, 1, 5);
+            let e12 = sut.add_edge(1, 2, 3);
+            // When
+            sut.max_flow(0, 2);
+            // Then
+            assert_eq!((0, 1, 5, 3), sut.get_edge(e01));
+            assert_eq!((1, 2, 3, 3), sut.get_edge(e12));
+        }
+
+        /// Scenario: 同じ2頂点間の複数辺 (多重辺) の容量も合算して流せる。
+        /// - Given: `0 -> 1` 間に容量2の辺が2本あるグラフがある。
+        /// - When: 0 から 1 への最大流を求める。
+        /// - Then: 最大流は 4 (2本の辺の容量の和) になる。
+        #[test]
+        fn sums_capacities_of_multi_edges() {
+            // Given
+            let mut sut = FlowGraph::<i64>::new(2);
+            sut.add_edge(0, 1, 2);
+            sut.add_edge(0, 1, 2);
+            // When
+            let result = sut.max_flow(0, 1);
+            // Then
+            assert_eq!(4, result);
+        }
+
+        /// Scenario: s と t が同じ頂点であれば、パニックする (異常系)。
+        /// - Given: 2頂点のグラフがある。
+        /// - When: 同じ頂点を始点・終点として最大流を求めようとする。
+        /// - Then: パニックする。
+        #[test]
+        #[should_panic(expected = "s and t must be different vertices")]
+        fn panics_when_source_and_sink_are_the_same() {
+            // Given
+            let mut sut = FlowGraph::<i64>::new(2);
+            // When, Then (panic)
+            sut.max_flow(0, 0);
+        }
+    }
+
+    // min_cut のテスト: 戻り値そのものを検証する。
+    mod min_cut {
+        use super::*;
+
+        /// Scenario: 最大流を求めた後、飽和した辺の先には到達できない。
+        /// - Given: `0 -> 1 -> 2` (容量3, 1) の経路がある。
+        /// - When: 最大流を求めた後、0 を含む側の最小カットを求める。
+        /// - Then: 0 と 1 はカットの s 側に含まれ、2 は含まれない
+        ///   (`1->2` が飽和しているため)。
+        #[test]
+        fn excludes_vertices_beyond_saturated_edge() {
+            // Given
+            let mut sut = FlowGraph::<i64>::new(3);
+            sut.add_edge(0, 1, 3);
+            sut.add_edge(1, 2, 1);
+            // When
+            sut.max_flow(0, 2);
+            let result = sut.min_cut(0);
+            // Then
+            assert!(result[0]);
+            assert!(result[1]);
+            assert!(!result[2]);
+        }
+    }
+}

--- a/src/graph/min_cost_flow.rs
+++ b/src/graph/min_cost_flow.rs
@@ -1,0 +1,343 @@
+//! ポテンシャルを用いた successive shortest path 法による、最小費用流の計算を
+//! 提供するモジュールである。
+//!
+//! 「始点から終点への、残余グラフ上でコストが最小となる経路」を1本ずつ選んで
+//! 流すことを、それ以上流せなくなるまで繰り返す。これを最大流まで続けた結果が、
+//! 最大流量における最小コストになる (各増加が最小コストの経路を使うため、
+//! 流量を増やすたびに単調に最適性が保たれる)。
+//!
+//! 負のコストを持つ辺があってもダイクストラ法をそのまま使えるように、頂点
+//! ごとのポテンシャル `h` を保持し、コストを「還元コスト」
+//! `cost(u, v) + h[u] - h[v]` に置き換えて扱う。最初のポテンシャルは、負の
+//! コストを含みうる元のグラフに対して1回だけベルマン-フォード法を行うことで
+//! 求める。増加のたびにポテンシャルを最短距離だけ更新すると、還元コストは
+//! 常に非負に保たれることが知られており、2回目以降の増加はダイクストラ法
+//! だけで済む。
+
+use std::{cmp, collections};
+
+use super::min_cost_flow_graph::{self, MinCostFlowGraph};
+
+impl<T: min_cost_flow_graph::FlowValue> MinCostFlowGraph<T> {
+    /// successive shortest path 法により、頂点 `s` から頂点 `t` への
+    /// 最大流量における最小コストを求める。
+    ///
+    /// 呼び出し後、内部の残余容量は最小費用最大流を実現した状態に更新されて
+    /// いる。各辺の流量は [`get_edge`](Self::get_edge) で参照できる。
+    ///
+    /// # Args
+    /// - `s`: 始点。`0..vertex_count()` の範囲でなければならない。
+    /// - `t`: 終点。`0..vertex_count()` の範囲でなければならず、`s` と異なって
+    ///   いなければならない。
+    ///
+    /// # Returns
+    /// `(T, T)`: `(s から t への最大流量, その流量を実現する最小コスト)`。
+    ///
+    /// # Panics
+    /// - `s == t` の場合にパニックする。
+    /// - `s`/`t` が `0..vertex_count()` の範囲外の場合にパニックする。
+    ///
+    /// # Constraints
+    /// - `s` から、残余容量が正の辺のみを辿って到達できる範囲に、コストが
+    ///   負の閉路があってはならない。存在すると、コストがいくらでも小さく
+    ///   できてしまい、最小コストが定義できない。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(VE + F E log V)
+    ///   - V は頂点数、E は辺数、F は最大流量である。ポテンシャルの初期化に
+    ///     ベルマン-フォード法で O(VE)、以降の各増加にダイクストラ法で
+    ///     O(E log V) かかる。
+    /// - 空間計算量: O(V)
+    ///
+    /// # Examples
+    /// ```
+    /// use anmitsu::graph::min_cost_flow_graph::MinCostFlowGraph;
+    ///
+    /// // 0 -> 1 -> 2 の経路 (容量2, コスト3) と、0 -> 2 への直接の安い経路
+    /// // (容量1, コスト1) を持つグラフ。
+    /// let mut g = MinCostFlowGraph::<i64>::new(3);
+    /// g.add_edge(0, 1, 2, 3);
+    /// g.add_edge(1, 2, 2, 3);
+    /// g.add_edge(0, 2, 1, 1);
+    ///
+    /// let (flow, cost) = g.min_cost_flow(0, 2);
+    /// assert_eq!(3, flow);
+    /// // 安い直接経路 (1単位, コスト1) をまず使い、残り2単位は
+    /// // 0->1->2 (単位あたりコスト6) を使う。
+    /// assert_eq!(1 * 1 + 2 * 6, cost);
+    /// ```
+    pub fn min_cost_flow(&mut self, s: usize, t: usize) -> (T, T) {
+        debug_assert!(s != t, "s and t must be different vertices");
+
+        let n = self.vertex_count();
+        let mut potential = self.bellman_ford_potential(s);
+
+        let mut flow = T::ZERO;
+        let mut cost = T::ZERO;
+
+        loop {
+            let ShortestPath { dist, prev_edge } = self.dijkstra_with_potential(s, &potential);
+            if dist[t].is_none() {
+                // これ以上、t へ到達できる増加パスが存在しない。
+                break;
+            }
+
+            // ポテンシャルを最短距離だけ更新する。これにより、次回の還元
+            // コストも非負に保たれる。到達できなかった頂点のポテンシャルは
+            // 以降のパス探索で使われることがないため、更新しなくてよい。
+            for v in 0..n {
+                if let Some(d) = dist[v] {
+                    potential[v] = potential[v] + d;
+                }
+            }
+
+            // s から t への経路をたどり、ボトルネックとなる残余容量を求める。
+            let mut bottleneck = T::MAX;
+            let mut v = t;
+            while let Some((u, idx)) = prev_edge[v] {
+                bottleneck = bottleneck.min(self.graph[u][idx].cap);
+                v = u;
+            }
+
+            // 経路上の各辺に、ボトルネック分の流量を反映する。
+            let mut v = t;
+            while let Some((u, idx)) = prev_edge[v] {
+                let edge_to = self.graph[u][idx].to;
+                let edge_rev = self.graph[u][idx].rev;
+                self.graph[u][idx].cap = self.graph[u][idx].cap - bottleneck;
+                self.graph[edge_to][edge_rev].cap = self.graph[edge_to][edge_rev].cap + bottleneck;
+                v = u;
+            }
+
+            flow = flow + bottleneck;
+            // s のポテンシャルは常に0に保たれるため、更新後の t のポテンシャル
+            // が、そのまま今回の経路の (元のコストでの) 総和に一致する。
+            cost = cost + bottleneck * potential[t];
+        }
+
+        (flow, cost)
+    }
+
+    /// 負のコストを含みうる元のグラフに対して、始点 `s` からの最短距離を
+    /// ベルマン-フォード法で求め、初期ポテンシャルとする。
+    ///
+    /// 呼び出し時点ではまだ流量が押し出されていないため、逆辺の残余容量は
+    /// すべて0であり、実質的に元の辺のみを辿ることになる。
+    ///
+    /// # Args
+    /// - `s`: 始点。
+    ///
+    /// # Returns
+    /// `Vec<T>`: `result[v]` は `s` から `v` への最短距離。到達できない頂点は
+    /// 以降のポテンシャルとして使われることがないため、`T::ZERO` を割り当てる。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(VE)
+    fn bellman_ford_potential(&self, s: usize) -> Vec<T> {
+        let n = self.vertex_count();
+        let mut dist = vec![None; n];
+        dist[s] = Some(T::ZERO);
+
+        // n-1 回の緩和で、負の閉路が存在しない限り最短距離が確定する。
+        for _ in 0..n {
+            let mut updated = false;
+            for u in 0..n {
+                let Some(du) = dist[u] else {
+                    continue;
+                };
+                for edge in &self.graph[u] {
+                    if edge.cap > T::ZERO {
+                        let nd = du + edge.cost;
+                        let is_better = match dist[edge.to] {
+                            Some(cur) => nd < cur,
+                            None => true,
+                        };
+                        if is_better {
+                            dist[edge.to] = Some(nd);
+                            updated = true;
+                        }
+                    }
+                }
+            }
+            if !updated {
+                break;
+            }
+        }
+
+        dist.into_iter().map(|d| d.unwrap_or(T::ZERO)).collect()
+    }
+
+    /// 頂点ごとのポテンシャル `potential` を用いた還元コストのもとで、
+    /// 始点 `s` からの最短距離をダイクストラ法で求める。
+    ///
+    /// # Args
+    /// - `s`: 始点。
+    /// - `potential`: 頂点ごとのポテンシャル。還元コスト
+    ///   `cost(u, v) + potential[u] - potential[v]` が非負になっている必要が
+    ///   ある。
+    ///
+    /// # Returns
+    /// `ShortestPath<T>`: 還元コストでの最短距離と、経路復元に必要な情報。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(E log V)
+    fn dijkstra_with_potential(&self, s: usize, potential: &[T]) -> ShortestPath<T> {
+        let n = self.vertex_count();
+        let mut dist: Vec<Option<T>> = vec![None; n];
+        let mut prev_edge = vec![None; n];
+        dist[s] = Some(T::ZERO);
+
+        let mut heap = collections::BinaryHeap::new();
+        heap.push(cmp::Reverse((T::ZERO, s)));
+
+        while let Some(cmp::Reverse((d, u))) = heap.pop() {
+            if dist[u] != Some(d) {
+                continue;
+            }
+
+            for (idx, edge) in self.graph[u].iter().enumerate() {
+                if edge.cap > T::ZERO {
+                    let reduced_cost = edge.cost + potential[u] - potential[edge.to];
+                    let nd = d + reduced_cost;
+                    let is_better = match dist[edge.to] {
+                        Some(cur) => nd < cur,
+                        None => true,
+                    };
+                    if is_better {
+                        dist[edge.to] = Some(nd);
+                        prev_edge[edge.to] = Some((u, idx));
+                        heap.push(cmp::Reverse((nd, edge.to)));
+                    }
+                }
+            }
+        }
+
+        ShortestPath { dist, prev_edge }
+    }
+}
+
+/// [`dijkstra_with_potential`](MinCostFlowGraph::dijkstra_with_potential) の
+/// 結果を保持する。
+struct ShortestPath<T> {
+    /// `dist[v]` は、還元コストのもとでの `s` から `v` への最短距離。
+    /// 到達できない場合は `None`。
+    dist: Vec<Option<T>>,
+    /// `prev_edge[v]` は、最短路上で `v` の直前に使った
+    /// `(頂点, その頂点の隣接リスト内での辺の添字)`。`s` 自身、または到達
+    /// できない頂点では `None`。
+    prev_edge: Vec<Option<(usize, usize)>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // min_cost_flow のテスト: 戻り値そのものと、呼び出し後に get_edge で
+    // 観測できる各辺の流量を検証する。
+    mod min_cost_flow {
+        use super::*;
+
+        /// Scenario: 安い直接経路を優先しつつ、残りは高い経路で補って
+        /// 流し切る。
+        /// - Given: `0->1->2` (容量2, 単位コスト3ずつ) と、`0->2` への
+        ///   直接の安い経路 (容量1, 単位コスト1) がある。
+        /// - When: 0 から 2 への最小費用流を求める。
+        /// - Then: 最大流量は3になり、コストは 1*1 + 2*6 = 13 になる。
+        #[test]
+        fn prefers_cheaper_route_before_using_expensive_one() {
+            // Given
+            let mut sut = MinCostFlowGraph::<i64>::new(3);
+            sut.add_edge(0, 1, 2, 3);
+            sut.add_edge(1, 2, 2, 3);
+            sut.add_edge(0, 2, 1, 1);
+            // When
+            let (flow, cost) = sut.min_cost_flow(0, 2);
+            // Then
+            assert_eq!(3, flow);
+            assert_eq!(13, cost);
+        }
+
+        /// Scenario: 負のコストを持つ辺があっても正しく処理できる。
+        /// - Given: `0->1` (容量1, コスト -5) と `1->2` (容量1, コスト 2) の
+        ///   経路がある。
+        /// - When: 0 から 2 への最小費用流を求める。
+        /// - Then: 最大流量は1になり、コストは -3 (= -5 + 2) になる。
+        #[test]
+        fn handles_negative_cost_edge() {
+            // Given
+            let mut sut = MinCostFlowGraph::<i64>::new(3);
+            sut.add_edge(0, 1, 1, -5);
+            sut.add_edge(1, 2, 1, 2);
+            // When
+            let (flow, cost) = sut.min_cost_flow(0, 2);
+            // Then
+            assert_eq!(1, flow);
+            assert_eq!(-3, cost);
+        }
+
+        /// Scenario: 終点に到達できないグラフでは、流量・コストともに0に
+        /// なる (境界値)。
+        /// - Given: 0 から 1 への辺を持たない、孤立した頂点を含むグラフが
+        ///   ある。
+        /// - When: 0 から 1 への最小費用流を求める。
+        /// - Then: 流量・コストともに0になる。
+        #[test]
+        fn returns_zero_when_sink_is_unreachable() {
+            // Given
+            let mut sut = MinCostFlowGraph::<i64>::new(2);
+            // When
+            let (flow, cost) = sut.min_cost_flow(0, 1);
+            // Then
+            assert_eq!(0, flow);
+            assert_eq!(0, cost);
+        }
+
+        /// Scenario: 複数の経路のうち、単位コストが最も低い経路から順に
+        /// 使われる。
+        /// - Given: `0->1` の並列な2辺 (容量1・単位コスト1, 容量1・単位
+        ///   コスト5) がある。
+        /// - When: 0 から 1 への最小費用流を求める。
+        /// - Then: 流量は2 (両方の辺を使い切る) になり、コストは
+        ///   1 + 5 = 6 になる。
+        #[test]
+        fn uses_cheaper_parallel_edge_first() {
+            // Given
+            let mut sut = MinCostFlowGraph::<i64>::new(2);
+            sut.add_edge(0, 1, 1, 5);
+            sut.add_edge(0, 1, 1, 1);
+            // When
+            let (flow, cost) = sut.min_cost_flow(0, 1);
+            // Then
+            assert_eq!(2, flow);
+            assert_eq!(6, cost);
+        }
+
+        /// Scenario: 呼び出し後、各辺の流量を get_edge で参照できる。
+        /// - Given: `0->1` (容量3, コスト1) の単純な辺がある。
+        /// - When: 0 から 1 への最小費用流を求める。
+        /// - Then: `get_edge` で流量が3 (容量いっぱい) と観測できる。
+        #[test]
+        fn exposes_flow_per_edge_via_get_edge() {
+            // Given
+            let mut sut = MinCostFlowGraph::<i64>::new(2);
+            let e01 = sut.add_edge(0, 1, 3, 1);
+            // When
+            sut.min_cost_flow(0, 1);
+            // Then
+            assert_eq!((0, 1, 3, 1, 3), sut.get_edge(e01));
+        }
+
+        /// Scenario: s と t が同じ頂点であれば、パニックする (異常系)。
+        /// - Given: 2頂点のグラフがある。
+        /// - When: 同じ頂点を始点・終点として最小費用流を求めようとする。
+        /// - Then: パニックする。
+        #[test]
+        #[should_panic(expected = "s and t must be different vertices")]
+        fn panics_when_source_and_sink_are_the_same() {
+            // Given
+            let mut sut = MinCostFlowGraph::<i64>::new(2);
+            // When, Then (panic)
+            sut.min_cost_flow(0, 0);
+        }
+    }
+}

--- a/src/graph/min_cost_flow.rs
+++ b/src/graph/min_cost_flow.rs
@@ -143,9 +143,14 @@ impl<T: min_cost_flow_graph::FlowValue> MinCostFlowGraph<T> {
         for _ in 0..n {
             let mut updated = false;
             for u in 0..n {
+                // まだコストが確定していない頂点 (dist[u] が None) からは、
+                // どの辺を辿っても意味のある更新にならないため読み飛ばす。
                 let Some(du) = dist[u] else {
                     continue;
                 };
+                // 頂点 u から出る各辺のうち、残余容量が正のものについて、
+                // その辺を使うことで隣接頂点 to までのコストがこれまでより
+                // 小さくできるなら更新する (「緩和」と呼ばれる操作)。
                 for edge in &self.graph[u] {
                     if edge.cap > T::ZERO {
                         let nd = du + edge.cost;
@@ -160,6 +165,8 @@ impl<T: min_cost_flow_graph::FlowValue> MinCostFlowGraph<T> {
                     }
                 }
             }
+            // このラウンドで1件も緩和が起きなければ、以降のラウンドを繰り返し
+            // ても結果は変わらないため、早期に終了する。
             if !updated {
                 break;
             }
@@ -188,14 +195,28 @@ impl<T: min_cost_flow_graph::FlowValue> MinCostFlowGraph<T> {
         let mut prev_edge = vec![None; n];
         dist[s] = Some(T::ZERO);
 
+        // (還元コストでの距離, 頂点) の組を、距離が小さい順に取り出すための
+        // 優先度キュー。`BinaryHeap` は最大値を先頭に取るため、`Reverse` で
+        // 反転させる。
         let mut heap = collections::BinaryHeap::new();
         heap.push(cmp::Reverse((T::ZERO, s)));
 
+        // キューから距離が最小の頂点を1つずつ取り出し、確定させていく。
+        // 還元コストは非負であるため、一度取り出した頂点の距離はそれ以上
+        // 小さくなることがなく、以降変化しない (確定する)。
         while let Some(cmp::Reverse((d, u))) = heap.pop() {
+            // このキューには、同じ頂点について古い距離のエントリが複数
+            // 積まれていることがある (下の更新のたびに新しいエントリを追加で
+            // 積んでいるだけで、古いエントリを取り除いていないため)。
+            // dist[u] と一致しない (= 既により良い距離で確定済みの) エントリは
+            // 読み捨てる。
             if dist[u] != Some(d) {
                 continue;
             }
 
+            // 確定した頂点 u から出る各辺のうち、残余容量が正のものについて、
+            // 還元コスト `cost(u, to) + potential[u] - potential[to]` を使って
+            // 隣接頂点 to までの距離がこれまでより小さくできるなら更新する。
             for (idx, edge) in self.graph[u].iter().enumerate() {
                 if edge.cap > T::ZERO {
                     let reduced_cost = edge.cost + potential[u] - potential[edge.to];

--- a/src/graph/min_cost_flow.rs
+++ b/src/graph/min_cost_flow.rs
@@ -26,12 +26,12 @@ impl<T: min_cost_flow_graph::FlowValue> MinCostFlowGraph<T> {
     /// いる。各辺の流量は [`get_edge`](Self::get_edge) で参照できる。
     ///
     /// # Args
-    /// - `s`: 始点。`0..vertex_count()` の範囲でなければならない。
-    /// - `t`: 終点。`0..vertex_count()` の範囲でなければならず、`s` と異なって
-    ///   いなければならない。
+    /// - `s`: 始点であり、`0..vertex_count()` の範囲でなければならない。
+    /// - `t`: 終点であり、`0..vertex_count()` の範囲でなければならず、`s` と
+    ///   異なっていなければならない。
     ///
     /// # Returns
-    /// `(T, T)`: `(s から t への最大流量, その流量を実現する最小コスト)`。
+    /// `(T, T)`: `(s から t への最大流量, その流量を実現する最小コスト)`
     ///
     /// # Panics
     /// - `s == t` の場合にパニックする。
@@ -125,11 +125,12 @@ impl<T: min_cost_flow_graph::FlowValue> MinCostFlowGraph<T> {
     /// すべて0であり、実質的に元の辺のみを辿ることになる。
     ///
     /// # Args
-    /// - `s`: 始点。
+    /// - `s`: 始点
     ///
     /// # Returns
-    /// `Vec<T>`: `result[v]` は `s` から `v` への最短距離。到達できない頂点は
-    /// 以降のポテンシャルとして使われることがないため、`T::ZERO` を割り当てる。
+    /// `Vec<T>`: `result[v]` は `s` から `v` への最短距離であり、到達できない
+    /// 頂点は以降のポテンシャルとして使われることがないため、`T::ZERO` を
+    /// 割り当てる。
     ///
     /// # Complexity
     /// - 時間計算量: O(VE)
@@ -171,13 +172,13 @@ impl<T: min_cost_flow_graph::FlowValue> MinCostFlowGraph<T> {
     /// 始点 `s` からの最短距離をダイクストラ法で求める。
     ///
     /// # Args
-    /// - `s`: 始点。
-    /// - `potential`: 頂点ごとのポテンシャル。還元コスト
+    /// - `s`: 始点
+    /// - `potential`: 頂点ごとのポテンシャルであり、還元コスト
     ///   `cost(u, v) + potential[u] - potential[v]` が非負になっている必要が
     ///   ある。
     ///
     /// # Returns
-    /// `ShortestPath<T>`: 還元コストでの最短距離と、経路復元に必要な情報。
+    /// `ShortestPath<T>`: 還元コストでの最短距離と、経路復元に必要な情報
     ///
     /// # Complexity
     /// - 時間計算量: O(E log V)

--- a/src/graph/min_cost_flow_graph.rs
+++ b/src/graph/min_cost_flow_graph.rs
@@ -73,10 +73,10 @@ impl<T> MinCostFlowGraph<T> {
     /// `n` 頂点、辺を持たない最小費用流グラフを生成する。
     ///
     /// # Args
-    /// - `n`: 頂点数。
+    /// - `n`: 頂点数
     ///
     /// # Returns
-    /// `Self`: 頂点数 `n`、辺を持たない `MinCostFlowGraph<T>`。
+    /// `Self`: 頂点数 `n`、辺を持たない `MinCostFlowGraph<T>`
     ///
     /// # Complexity
     /// - 時間計算量: O(n)
@@ -92,7 +92,7 @@ impl<T> MinCostFlowGraph<T> {
     /// グラフの頂点数を返す。
     ///
     /// # Returns
-    /// `usize`: 頂点数。
+    /// `usize`: 頂点数
     ///
     /// # Complexity
     /// - 時間計算量: O(1)
@@ -103,7 +103,7 @@ impl<T> MinCostFlowGraph<T> {
     /// これまでに追加した辺の本数を返す。
     ///
     /// # Returns
-    /// `usize`: 追加した辺の本数。
+    /// `usize`: 追加した辺の本数
     ///
     /// # Complexity
     /// - 時間計算量: O(1)
@@ -117,14 +117,14 @@ impl<T: FlowValue> MinCostFlowGraph<T> {
     /// 追加し、辺番号を返す。
     ///
     /// # Args
-    /// - `from`: 辺の始点。`0..vertex_count()` の範囲でなければならない。
-    /// - `to`: 辺の終点。`0..vertex_count()` の範囲でなければならない。
-    /// - `cap`: 辺の容量。非負でなければならない。
-    /// - `cost`: 辺の単位流量あたりのコスト。正負は問わない。
+    /// - `from`: 辺の始点であり、`0..vertex_count()` の範囲でなければならない。
+    /// - `to`: 辺の終点であり、`0..vertex_count()` の範囲でなければならない。
+    /// - `cap`: 辺の容量であり、非負でなければならない。
+    /// - `cost`: 辺の単位流量あたりのコストであり、正負は問わない。
     ///
     /// # Returns
-    /// `usize`: 追加した辺の番号。[`get_edge`](Self::get_edge) で参照する際に
-    /// 使う。
+    /// `usize`: 追加した辺の番号であり、[`get_edge`](Self::get_edge) で参照する
+    /// 際に使う。
     ///
     /// # Panics
     /// - `from`/`to` が `0..vertex_count()` の範囲外の場合にパニックする。
@@ -174,10 +174,10 @@ impl<T: FlowValue> MinCostFlowGraph<T> {
     /// 現在の流量に等しい。
     ///
     /// # Args
-    /// - `i`: 辺番号。[`add_edge`](Self::add_edge) の戻り値。
+    /// - `i`: 辺番号であり、[`add_edge`](Self::add_edge) の戻り値である。
     ///
     /// # Returns
-    /// `(usize, usize, T, T, T)`: `(始点, 終点, 元の容量, コスト, 現在の流量)`。
+    /// `(usize, usize, T, T, T)`: `(始点, 終点, 元の容量, コスト, 現在の流量)`
     ///
     /// # Panics
     /// - `i` が `0..edge_count()` の範囲外の場合にパニックする。

--- a/src/graph/min_cost_flow_graph.rs
+++ b/src/graph/min_cost_flow_graph.rs
@@ -1,0 +1,266 @@
+//! 最小費用流問題を扱うためのグラフ構造 `MinCostFlowGraph<T>` を提供する
+//! モジュールである。
+//!
+//! [`FlowGraph<Cap>`](super::flow_graph::FlowGraph) と同様に、各辺に逆辺への
+//! インデックスを直接持たせることで、逆辺の残余容量を O(1) で参照・更新できる
+//! ようにする。最小費用流ではさらに各辺がコストを持ち、逆辺には元の辺の
+//! 符号を反転したコストを持たせる。容量とコストは、負の値を取りうるコストの
+//! 都合上、同じ数値型 `T` として扱う (競技プログラミングでは両者を `i64` など
+//! 単一の整数型で表すことがほとんどであり、型を分けて相互の乗算・変換を
+//! 扱う複雑さを負うだけの利点に乏しいための選択である)。
+
+use std::ops;
+
+/// フロー問題における容量・コストとして利用可能な数値型が満たすべき制約を
+/// まとめた trait である。
+///
+/// コストが負の値を取りうるため `Neg` を要求する。また、流量とコストの積を
+/// 計算するために `Mul` を要求する。
+pub trait FlowValue:
+    Copy
+    + Ord
+    + ops::Add<Output = Self>
+    + ops::Sub<Output = Self>
+    + ops::Mul<Output = Self>
+    + ops::Neg<Output = Self>
+{
+    /// 加法の単位元 (0)。
+    const ZERO: Self;
+    /// この型が表現できる最大値。増加パス探索の初期上界として使う。
+    const MAX: Self;
+}
+
+macro_rules! impl_flow_value {
+    ($($t:ty),*) => {
+        $(
+            impl FlowValue for $t {
+                const ZERO: Self = 0;
+                const MAX: Self = <$t>::MAX;
+            }
+        )*
+    };
+}
+impl_flow_value!(i32, i64);
+
+/// 残余グラフ上の1本の有向辺を表す。
+pub(super) struct ResidualEdge<T> {
+    /// 辺の終点。
+    pub(super) to: usize,
+    /// 残余容量。
+    pub(super) cap: T,
+    /// 単位流量あたりのコスト。逆辺では、元の辺のコストの符号を反転した値に
+    /// なる。
+    pub(super) cost: T,
+    /// 逆辺 (終点側の隣接リストに張られている、この辺に対応する辺) の、
+    /// 隣接リスト内でのインデックス。
+    pub(super) rev: usize,
+}
+
+/// 最小費用流問題を表現する有向グラフ。各辺には非負の容量と、正負を問わない
+/// コストを持たせる。
+pub struct MinCostFlowGraph<T> {
+    /// `graph[u]` は、頂点 `u` から出る残余辺の並びである。各辺を追加した際、
+    /// コストの符号を反転した逆辺 (残余容量0で初期化) も終点側に同時に
+    /// 追加される。
+    pub(super) graph: Vec<Vec<ResidualEdge<T>>>,
+    /// `pos[i]` は、`i` 番目に追加した辺の `(始点, 始点の隣接リスト内での添字)`
+    /// の組である。追加後の残余容量や流量を、辺番号から引けるようにするために
+    /// 使う。
+    pos: Vec<(usize, usize)>,
+}
+
+impl<T> MinCostFlowGraph<T> {
+    /// `n` 頂点、辺を持たない最小費用流グラフを生成する。
+    ///
+    /// # Args
+    /// - `n`: 頂点数。
+    ///
+    /// # Returns
+    /// `Self`: 頂点数 `n`、辺を持たない `MinCostFlowGraph<T>`。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(n)
+    /// - 空間計算量: O(n)
+    #[must_use]
+    pub fn new(n: usize) -> Self {
+        MinCostFlowGraph {
+            graph: (0..n).map(|_| Vec::new()).collect::<Vec<_>>(),
+            pos: Vec::new(),
+        }
+    }
+
+    /// グラフの頂点数を返す。
+    ///
+    /// # Returns
+    /// `usize`: 頂点数。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(1)
+    pub fn vertex_count(&self) -> usize {
+        self.graph.len()
+    }
+
+    /// これまでに追加した辺の本数を返す。
+    ///
+    /// # Returns
+    /// `usize`: 追加した辺の本数。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(1)
+    pub fn edge_count(&self) -> usize {
+        self.pos.len()
+    }
+}
+
+impl<T: FlowValue> MinCostFlowGraph<T> {
+    /// 容量 `cap`、単位流量あたりのコスト `cost` の有向辺 `from -> to` を
+    /// 追加し、辺番号を返す。
+    ///
+    /// # Args
+    /// - `from`: 辺の始点。`0..vertex_count()` の範囲でなければならない。
+    /// - `to`: 辺の終点。`0..vertex_count()` の範囲でなければならない。
+    /// - `cap`: 辺の容量。非負でなければならない。
+    /// - `cost`: 辺の単位流量あたりのコスト。正負は問わない。
+    ///
+    /// # Returns
+    /// `usize`: 追加した辺の番号。[`get_edge`](Self::get_edge) で参照する際に
+    /// 使う。
+    ///
+    /// # Panics
+    /// - `from`/`to` が `0..vertex_count()` の範囲外の場合にパニックする。
+    ///
+    /// # Complexity
+    /// - 時間計算量: 償却 O(1)
+    ///
+    /// # Examples
+    /// ```
+    /// use anmitsu::graph::min_cost_flow_graph::MinCostFlowGraph;
+    ///
+    /// let mut g = MinCostFlowGraph::<i64>::new(2);
+    /// let id = g.add_edge(0, 1, 5, 3);
+    /// assert_eq!((0, 1, 5, 3, 0), g.get_edge(id));
+    /// ```
+    pub fn add_edge(&mut self, from: usize, to: usize, cap: T, cost: T) -> usize {
+        let id = self.edge_count();
+
+        // 自己ループ (from == to) の場合、順辺と逆辺が同じ頂点の隣接リストへ
+        // 追加されるため、逆辺のインデックスは「追加前の長さ + 1」になる。
+        let from_index = self.graph[from].len();
+        let to_index = self.graph[to].len() + usize::from(from == to);
+
+        self.pos.push((from, from_index));
+        self.graph[from].push(ResidualEdge {
+            to,
+            cap,
+            cost,
+            rev: to_index,
+        });
+        self.graph[to].push(ResidualEdge {
+            to: from,
+            cap: T::ZERO,
+            cost: -cost,
+            rev: from_index,
+        });
+
+        id
+    }
+
+    /// `i` 番目に追加した辺の `(始点, 終点, 元の容量, コスト, 現在の流量)` を
+    /// 返す。
+    ///
+    /// 元の容量は、順辺の残余容量と逆辺の残余容量の和として求まる。両者の和は
+    /// 流量の増減によらず常に元の容量に保たれるからである。また、逆辺の残余
+    /// 容量は0から始まり流量が押し出されるたびに増加するため、そのままこの辺の
+    /// 現在の流量に等しい。
+    ///
+    /// # Args
+    /// - `i`: 辺番号。[`add_edge`](Self::add_edge) の戻り値。
+    ///
+    /// # Returns
+    /// `(usize, usize, T, T, T)`: `(始点, 終点, 元の容量, コスト, 現在の流量)`。
+    ///
+    /// # Panics
+    /// - `i` が `0..edge_count()` の範囲外の場合にパニックする。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(1)
+    pub fn get_edge(&self, i: usize) -> (usize, usize, T, T, T) {
+        let (from, index) = self.pos[i];
+        let edge = &self.graph[from][index];
+        let reverse = &self.graph[edge.to][edge.rev];
+        (from, edge.to, edge.cap + reverse.cap, edge.cost, reverse.cap)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // new のテスト: 生成直後の状態を検証する。
+    mod new {
+        use super::*;
+
+        /// Scenario: 生成直後の最小費用流グラフは、指定した頂点数を持ち、
+        /// 辺を持たない。
+        /// - Given: 頂点数 3 を指定する。
+        /// - When: `MinCostFlowGraph::new(3)` を呼ぶ。
+        /// - Then: `vertex_count()` が 3 を返し、`edge_count()` が 0 を返す。
+        #[test]
+        fn creates_graph_with_given_vertex_count_and_no_edges() {
+            // Given, When
+            let sut = MinCostFlowGraph::<i64>::new(3);
+            // Then
+            assert_eq!(3, sut.vertex_count());
+            assert_eq!(0, sut.edge_count());
+        }
+    }
+
+    // add_edge のテスト: 呼び出し後の状態変化 (get_edge で観測できる内容) を
+    // 検証する。
+    mod add_edge {
+        use super::*;
+
+        /// Scenario: 辺を追加すると、流量0の状態で観測できる。
+        /// - Given: 2頂点、辺を持たないグラフがある。
+        /// - When: `0 -> 1` に容量5、コスト3の辺を追加する。
+        /// - Then: `get_edge` で `(0, 1, 5, 3, 0)` が観測できる。
+        #[test]
+        fn records_edge_with_zero_flow() {
+            // Given
+            let mut sut = MinCostFlowGraph::<i64>::new(2);
+            // When
+            let id = sut.add_edge(0, 1, 5, 3);
+            // Then
+            assert_eq!((0, 1, 5, 3, 0), sut.get_edge(id));
+        }
+
+        /// Scenario: 負のコストを持つ辺も、そのまま観測できる (境界値)。
+        /// - Given: 2頂点、辺を持たないグラフがある。
+        /// - When: `0 -> 1` に容量2、コスト-4の辺を追加する。
+        /// - Then: `get_edge` で `(0, 1, 2, -4, 0)` が観測できる。
+        #[test]
+        fn allows_negative_cost() {
+            // Given
+            let mut sut = MinCostFlowGraph::<i64>::new(2);
+            // When
+            let id = sut.add_edge(0, 1, 2, -4);
+            // Then
+            assert_eq!((0, 1, 2, -4, 0), sut.get_edge(id));
+        }
+
+        /// Scenario: 自己ループを追加しても、逆辺の対応関係が壊れない
+        /// (境界値)。
+        /// - Given: 1頂点、辺を持たないグラフがある。
+        /// - When: `0 -> 0` に容量3、コスト2の自己ループを追加する。
+        /// - Then: `get_edge` で `(0, 0, 3, 2, 0)` が観測できる。
+        #[test]
+        fn keeps_reverse_edge_consistent_for_self_loop() {
+            // Given
+            let mut sut = MinCostFlowGraph::<i64>::new(1);
+            // When
+            let id = sut.add_edge(0, 0, 3, 2);
+            // Then
+            assert_eq!((0, 0, 3, 2, 0), sut.get_edge(id));
+        }
+    }
+}

--- a/src/graph/project_selection.rs
+++ b/src/graph/project_selection.rs
@@ -1,0 +1,405 @@
+//! Project Selection Problem (燃やす埋める問題) を最小カットに帰着させて解くための
+//! モジュールである。
+//!
+//! 各頂点に「選ぶ/選ばない」の二値を割り当てる問題のうち、次のような損得・制約の
+//! 組み合わせで表現できるものを、[`FlowGraph`] 上の最小カットとして解く。
+//!
+//! - 頂点ごとの損得 ([`add_weight`](ProjectSelection::add_weight))
+//! - 「u を選ぶなら v も選ばなければならない」という含意制約
+//!   ([`add_constraint`](ProjectSelection::add_constraint))
+//! - 複数の頂点をすべて選んだ場合にのみ得られる追加の報酬
+//!   ([`add_and_bonus_when_selected`](ProjectSelection::add_and_bonus_when_selected))
+//! - 複数の頂点をすべて選ばなかった場合にのみ得られる追加の報酬
+//!   ([`add_and_bonus_when_unselected`](ProjectSelection::add_and_bonus_when_unselected))
+//!
+//! 「選ぶ」を、最大流を求めたあとの残余グラフで始点から到達できる側 (
+//! [`min_cut`](super::max_flow) が返す側) と対応させる。頂点ごとの損得は、正なら
+//! 始点からその頂点への辺、負ならその頂点から終点への辺として表現し、選ばれな
+//! かった (または選ばれた) 場合にその分の損得を最小カットで打ち消す、という
+//! 考え方に基づく。後者2つの「すべて選んだ/選ばなかった場合の報酬」は、報酬を
+//! 表す補助頂点をもう1つ用意し、対象の頂点との間に含意制約を張ることで表現する。
+
+use super::flow_graph::{self, FlowGraph};
+
+/// Project Selection Problem を表現し、最小カットで解くための構造体である。
+pub struct ProjectSelection<Cap> {
+    flow: FlowGraph<Cap>,
+    source: usize,
+    sink: usize,
+    /// これまでに `add_weight` で加えた正の損得、および `add_and_bonus_when_*`
+    /// で加えた報酬の総和。選ばれなかった (または選ばれた) ことで打ち消される
+    /// 分を、最終的に最小カットの値だけ差し引く際の基準値として使う。
+    total_positive_weight: Cap,
+}
+
+impl<Cap: flow_graph::FlowCapacity> ProjectSelection<Cap> {
+    /// `n` 頂点分の Project Selection Problem を用意する。
+    ///
+    /// 頂点 `0..n` が選択対象の頂点である。
+    /// [`add_and_bonus_when_selected`](Self::add_and_bonus_when_selected) などで
+    /// 補助頂点を使う場合は、その分もあらかじめ `n` に含めておく必要がある。
+    ///
+    /// # Args
+    /// - `n`: 選択対象の頂点数であり、補助頂点として使う分も含める
+    ///
+    /// # Returns
+    /// `Self`: 頂点数 `n`、損得・制約を持たない `ProjectSelection<Cap>`
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(n)
+    #[must_use]
+    pub fn new(n: usize) -> Self {
+        ProjectSelection {
+            flow: FlowGraph::new(n + 2),
+            source: n,
+            sink: n + 1,
+            total_positive_weight: Cap::ZERO,
+        }
+    }
+
+    /// 頂点 `v` を選んだ場合の損得 `weight` を加える。
+    ///
+    /// `weight` が正であれば選んだ場合にその分の得を、負であれば選んだ場合に
+    /// その分の損を表す (選ばなければ、この呼び出しによる影響は 0 のままで
+    /// ある)。同じ頂点に複数回呼び出した場合、損得は加算される。
+    ///
+    /// # Args
+    /// - `v`: 頂点であり、`0..n` の範囲でなければならない (`n` は
+    ///   [`new`](Self::new) に渡した値である)。
+    /// - `weight`: `v` を選んだ場合の損得
+    ///
+    /// # Panics
+    /// - `v` が `0..n` の範囲外の場合にパニックする。
+    ///
+    /// # Complexity
+    /// - 時間計算量: 償却 O(1)
+    pub fn add_weight(&mut self, v: usize, weight: Cap) {
+        if weight > Cap::ZERO {
+            self.total_positive_weight = self.total_positive_weight + weight;
+            self.flow.add_edge(self.source, v, weight);
+        } else if weight < Cap::ZERO {
+            self.flow.add_edge(v, self.sink, Cap::ZERO - weight);
+        }
+    }
+
+    /// 頂点 `v` を必ず選ぶという制約を加える。
+    ///
+    /// あらかじめ値が確定している頂点を表すのに使う。[`add_weight`](Self::add_weight)
+    /// と異なり、損得の合計には影響しない。
+    ///
+    /// # Args
+    /// - `v`: 頂点であり、`0..n` の範囲でなければならない。
+    ///
+    /// # Panics
+    /// - `v` が `0..n` の範囲外の場合にパニックする。
+    ///
+    /// # Complexity
+    /// - 時間計算量: 償却 O(1)
+    pub fn force_selected(&mut self, v: usize) {
+        self.flow.add_edge(self.source, v, Cap::MAX);
+    }
+
+    /// 頂点 `v` を必ず選ばないという制約を加える。
+    ///
+    /// [`force_selected`](Self::force_selected) と対になる制約であり、損得の
+    /// 合計には影響しない。
+    ///
+    /// # Args
+    /// - `v`: 頂点であり、`0..n` の範囲でなければならない。
+    ///
+    /// # Panics
+    /// - `v` が `0..n` の範囲外の場合にパニックする。
+    ///
+    /// # Complexity
+    /// - 時間計算量: 償却 O(1)
+    pub fn force_unselected(&mut self, v: usize) {
+        self.flow.add_edge(v, self.sink, Cap::MAX);
+    }
+
+    /// 「頂点 `u` を選ぶなら頂点 `v` も選ばなければならない」という制約を加える。
+    ///
+    /// # Args
+    /// - `u`: 選ぶ側の頂点であり、`0..n` の範囲でなければならない。
+    /// - `v`: 連動して選ばれる側の頂点であり、`0..n` の範囲でなければならない。
+    ///
+    /// # Panics
+    /// - `u`/`v` が `0..n` の範囲外の場合にパニックする。
+    ///
+    /// # Complexity
+    /// - 時間計算量: 償却 O(1)
+    pub fn add_constraint(&mut self, u: usize, v: usize) {
+        self.flow.add_edge(u, v, Cap::MAX);
+    }
+
+    /// `vertices` に含まれる頂点をすべて選んだ場合にのみ、報酬 `bonus` を得る
+    /// という制約を加える。
+    ///
+    /// 内部では、報酬を表す補助頂点 `aux` を「選ぶと `bonus` を得る」頂点として
+    /// 扱ったうえで、`aux` を選ぶなら `vertices` の各頂点も選ばなければならない
+    /// という制約を加える。こうすることで、`aux` を選んでも損をしないのは
+    /// `vertices` がすべて選ばれているときに限られ、最小カットを求める過程で
+    /// 報酬を得るべきかどうかも同時に最適化される。
+    ///
+    /// # Args
+    /// - `vertices`: すべて選ばれていないと報酬を得られない頂点の集合であり、
+    ///   各要素は `0..n` の範囲でなければならない。
+    /// - `bonus`: すべて選んだ場合に得る報酬
+    /// - `aux`: この制約の表現に使う補助頂点であり、`0..n` の範囲でなければ
+    ///   ならず、他の用途に使っていない頂点でなければならない。
+    ///
+    /// # Panics
+    /// - `vertices` の要素や `aux` が `0..n` の範囲外の場合にパニックする。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(|vertices|)
+    pub fn add_and_bonus_when_selected(&mut self, vertices: &[usize], bonus: Cap, aux: usize) {
+        if bonus <= Cap::ZERO {
+            return;
+        }
+        self.total_positive_weight = self.total_positive_weight + bonus;
+        self.flow.add_edge(self.source, aux, bonus);
+        for &v in vertices {
+            self.flow.add_edge(aux, v, Cap::MAX);
+        }
+    }
+
+    /// `vertices` に含まれる頂点をすべて選ばなかった場合にのみ、報酬 `bonus` を
+    /// 得るという制約を加える。
+    ///
+    /// [`add_and_bonus_when_selected`](Self::add_and_bonus_when_selected) と
+    /// 対になる変換であり、`vertices` のいずれかを選ぶなら補助頂点 `aux` も
+    /// 選ばなければならない、という向きの制約を加えることで、`vertices` が
+    /// すべて選ばれていないときに限って `aux` を選ばずに済み、報酬を得られる
+    /// ようにする。
+    ///
+    /// # Args
+    /// - `vertices`: すべて選ばれていると報酬を得られない頂点の集合であり、
+    ///   各要素は `0..n` の範囲でなければならない。
+    /// - `bonus`: すべて選ばなかった場合に得る報酬
+    /// - `aux`: この制約の表現に使う補助頂点であり、`0..n` の範囲でなければ
+    ///   ならず、他の用途に使っていない頂点でなければならない。
+    ///
+    /// # Panics
+    /// - `vertices` の要素や `aux` が `0..n` の範囲外の場合にパニックする。
+    ///
+    /// # Complexity
+    /// - 時間計算量: O(|vertices|)
+    pub fn add_and_bonus_when_unselected(&mut self, vertices: &[usize], bonus: Cap, aux: usize) {
+        if bonus <= Cap::ZERO {
+            return;
+        }
+        self.total_positive_weight = self.total_positive_weight + bonus;
+        self.flow.add_edge(aux, self.sink, bonus);
+        for &v in vertices {
+            self.flow.add_edge(v, aux, Cap::MAX);
+        }
+    }
+
+    /// これまでに加えた損得・制約のもとで達成できる、損得の合計の最大値と、
+    /// それを実現する選択を求める。
+    ///
+    /// # Returns
+    /// `(Cap, Vec<bool>)`: 損得の合計の最大値であり、`selected[v]` が `true`
+    /// であれば頂点 `v` (`0..n`、`n` は [`new`](Self::new) に渡した値) が
+    /// 選ばれていることを表す配列
+    ///
+    /// # Complexity
+    /// - 時間計算量: [`max_flow`](FlowGraph::max_flow) の計算量に等しい
+    pub fn solve(&mut self) -> (Cap, Vec<bool>) {
+        let cut = self.flow.max_flow(self.source, self.sink);
+        let reachable = self.flow.min_cut(self.source);
+        let selected = reachable[..self.source].to_vec();
+        (self.total_positive_weight - cut, selected)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // force_selected/force_unselected のテスト: 値があらかじめ確定している
+    // 頂点を、損得に影響を与えずに固定できるかを検証する。
+    mod force {
+        use super::*;
+
+        /// Scenario: 単体では損な頂点でも、force_selected で固定すると選ばれる。
+        /// - Given: 頂点0 (損-5) を持つ ProjectSelection がある。
+        /// - When: 頂点0を force_selected で固定して解く。
+        /// - Then: 頂点0が選ばれ、合計値は -5 になる (固定自体は損得に影響しない)。
+        #[test]
+        fn selects_forced_vertex_even_at_a_loss() {
+            // Given
+            let mut sut = ProjectSelection::<i64>::new(1);
+            sut.add_weight(0, -5);
+            // When
+            sut.force_selected(0);
+            let (total, selected) = sut.solve();
+            // Then
+            assert_eq!(-5, total);
+            assert!(selected[0]);
+        }
+
+        /// Scenario: 単体では得な頂点でも、force_unselected で固定すると選ばれない。
+        /// - Given: 頂点0 (得+5) を持つ ProjectSelection がある。
+        /// - When: 頂点0を force_unselected で固定して解く。
+        /// - Then: 頂点0は選ばれず、合計値は 0 になる (固定自体は損得に影響しない)。
+        #[test]
+        fn excludes_forced_vertex_even_at_a_gain() {
+            // Given
+            let mut sut = ProjectSelection::<i64>::new(1);
+            sut.add_weight(0, 5);
+            // When
+            sut.force_unselected(0);
+            let (total, selected) = sut.solve();
+            // Then
+            assert_eq!(0, total);
+            assert!(!selected[0]);
+        }
+    }
+
+    // add_weight/add_constraint のテスト: 頂点ごとの損得と含意制約のみを
+    // 組み合わせた場合の戻り値 (合計値・選択) を検証する。
+    mod weight_and_constraint {
+        use super::*;
+
+        /// Scenario: 損得のみでは損をする頂点は選ばれない。
+        /// - Given: 頂点0 (得+10)、頂点1 (損-3) を持つ ProjectSelection がある。
+        /// - When: 特に制約を加えずに解く。
+        /// - Then: 頂点0のみが選ばれ、合計値は10になる。
+        #[test]
+        fn skips_vertex_that_only_loses() {
+            // Given
+            let mut sut = ProjectSelection::<i64>::new(2);
+            sut.add_weight(0, 10);
+            sut.add_weight(1, -3);
+            // When
+            let (total, selected) = sut.solve();
+            // Then
+            assert_eq!(10, total);
+            assert_eq!(vec![true, false], selected);
+        }
+
+        /// Scenario: 含意制約により、単体では損な頂点も連動して選ばれる。
+        /// - Given: 頂点0 (得+10)、頂点1 (損-3) を持ち、「0を選ぶなら1も選ぶ」
+        ///   という制約を加えた ProjectSelection がある。
+        /// - When: 解く。
+        /// - Then: 両方選ばれ、合計値は7 (10-3) になる。
+        #[test]
+        fn forces_dependent_vertex_via_constraint() {
+            // Given
+            let mut sut = ProjectSelection::<i64>::new(2);
+            sut.add_weight(0, 10);
+            sut.add_weight(1, -3);
+            sut.add_constraint(0, 1);
+            // When
+            let (total, selected) = sut.solve();
+            // Then
+            assert_eq!(7, total);
+            assert_eq!(vec![true, true], selected);
+        }
+
+        /// Scenario: 制約により連動先の損が大きすぎる場合は、そもそも選ばない。
+        /// - Given: 頂点0 (得+10)、頂点1 (損-20) を持ち、「0を選ぶなら1も選ぶ」
+        ///   という制約を加えた ProjectSelection がある。
+        /// - When: 解く。
+        /// - Then: どちらも選ばれず、合計値は0になる。
+        #[test]
+        fn avoids_vertex_when_forced_loss_outweighs_gain() {
+            // Given
+            let mut sut = ProjectSelection::<i64>::new(2);
+            sut.add_weight(0, 10);
+            sut.add_weight(1, -20);
+            sut.add_constraint(0, 1);
+            // When
+            let (total, selected) = sut.solve();
+            // Then
+            assert_eq!(0, total);
+            assert_eq!(vec![false, false], selected);
+        }
+    }
+
+    // add_and_bonus_when_selected のテスト: すべて選んだ場合にのみ得られる
+    // 報酬が正しく反映されるかを検証する。
+    mod and_bonus_when_selected {
+        use super::*;
+
+        /// Scenario: 損得の無い頂点同士なら、報酬を得るために両方選ばれる。
+        /// - Given: 頂点0, 1 (損得0) と補助頂点2 を持ち、両方選んだ場合に
+        ///   報酬5を得る制約を加えた ProjectSelection がある。
+        /// - When: 解く。
+        /// - Then: 頂点0, 1 が選ばれ、合計値は5になる。
+        #[test]
+        fn earns_bonus_when_free_to_select_both() {
+            // Given
+            let mut sut = ProjectSelection::<i64>::new(3);
+            sut.add_and_bonus_when_selected(&[0, 1], 5, 2);
+            // When
+            let (total, selected) = sut.solve();
+            // Then
+            assert_eq!(5, total);
+            assert!(selected[0]);
+            assert!(selected[1]);
+        }
+
+        /// Scenario: 一方に選ぶと損をする理由がある場合、報酬をあきらめて
+        /// そちらを優先することがある。
+        /// - Given: 頂点0 (損-10)、頂点1 (損得0) と補助頂点2 を持ち、両方選んだ
+        ///   場合に報酬5を得る制約を加えた ProjectSelection がある。
+        /// - When: 解く。
+        /// - Then: 頂点0は選ばれず、合計値は0になる (報酬をあきらめる方が得)。
+        #[test]
+        fn gives_up_bonus_when_forcing_costs_more() {
+            // Given
+            let mut sut = ProjectSelection::<i64>::new(3);
+            sut.add_weight(0, -10);
+            sut.add_and_bonus_when_selected(&[0, 1], 5, 2);
+            // When
+            let (total, selected) = sut.solve();
+            // Then
+            assert_eq!(0, total);
+            assert!(!selected[0]);
+        }
+    }
+
+    // add_and_bonus_when_unselected のテスト: すべて選ばなかった場合にのみ
+    // 得られる報酬が正しく反映されるかを検証する。
+    mod and_bonus_when_unselected {
+        use super::*;
+
+        /// Scenario: 損得の無い頂点同士なら、報酬を得るために両方選ばれない。
+        /// - Given: 頂点0, 1 (損得0) と補助頂点2 を持ち、両方選ばなかった場合に
+        ///   報酬5を得る制約を加えた ProjectSelection がある。
+        /// - When: 解く。
+        /// - Then: 頂点0, 1 はいずれも選ばれず、合計値は5になる。
+        #[test]
+        fn earns_bonus_when_free_to_leave_both_unselected() {
+            // Given
+            let mut sut = ProjectSelection::<i64>::new(3);
+            sut.add_and_bonus_when_unselected(&[0, 1], 5, 2);
+            // When
+            let (total, selected) = sut.solve();
+            // Then
+            assert_eq!(5, total);
+            assert!(!selected[0]);
+            assert!(!selected[1]);
+        }
+
+        /// Scenario: 選ぶ理由がある頂点を選ぶと、報酬をあきらめることがある。
+        /// - Given: 頂点0 (得+10)、頂点1 (損得0) と補助頂点2 を持ち、両方選ば
+        ///   なかった場合に報酬5を得る制約を加えた ProjectSelection がある。
+        /// - When: 解く。
+        /// - Then: 頂点0が選ばれ、合計値は10になる (報酬をあきらめる方が得)。
+        #[test]
+        fn gives_up_bonus_when_selecting_is_more_profitable() {
+            // Given
+            let mut sut = ProjectSelection::<i64>::new(3);
+            sut.add_weight(0, 10);
+            sut.add_and_bonus_when_unselected(&[0, 1], 5, 2);
+            // When
+            let (total, selected) = sut.solve();
+            // Then
+            assert_eq!(10, total);
+            assert!(selected[0]);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@ pub mod graph {
     pub mod johnson;
     pub mod low_link;
     pub mod max_flow;
+    pub mod min_cost_flow;
+    pub mod min_cost_flow_graph;
     pub mod mst;
     pub mod scc;
     pub mod topological_sort;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod graph {
     pub mod min_cost_flow;
     pub mod min_cost_flow_graph;
     pub mod mst;
+    pub mod project_selection;
     pub mod scc;
     pub mod topological_sort;
     pub mod two_sat;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,11 @@ pub mod graph {
     pub mod dijkstra;
     pub mod eulerian_path;
     pub mod floyd_warshall;
+    pub mod flow_graph;
     pub mod graph;
     pub mod johnson;
     pub mod low_link;
+    pub mod max_flow;
     pub mod mst;
     pub mod scc;
     pub mod topological_sort;

--- a/tests/bin/atcoder/abc193_f_zebraness.rs
+++ b/tests/bin/atcoder/abc193_f_zebraness.rs
@@ -1,0 +1,26 @@
+use rstest::rstest;
+
+use super::super::common;
+
+/// `ac-abc193-f-zebraness` バイナリへのパス。
+const BIN: &str = env!("CARGO_BIN_EXE_ac-abc193-f-zebraness");
+
+// ac-abc193-f-zebraness のテスト: 標準入力にサンプルを与えたときの標準出力を検証する
+mod ac_abc193_f_zebraness {
+    use super::*;
+
+    /// Scenario: 問題文の公式サンプルを解いたときの標準出力を検証する
+    /// - Given: 問題文の公式サンプルである
+    /// - When: ac-abc193-f-zebraness バイナリへ標準入力として渡す
+    /// - Then: しまうま度の最大値が期待値と一致する
+    #[rstest]
+    #[case::sample_1("2\nBB\nBW\n", "2\n")]
+    #[case::sample_2("3\nBBB\nBBB\nW?W\n", "4\n")]
+    #[case::sample_3_all_undetermined("5\n?????\n?????\n?????\n?????\n?????\n", "40\n")]
+    fn matches_official_samples(#[case] input: &str, #[case] expected: &str) {
+        // When
+        let result = common::run_binary(BIN, input);
+        // Then
+        assert_eq!(expected, result);
+    }
+}

--- a/tests/bin/atcoder/abc225_g_x.rs
+++ b/tests/bin/atcoder/abc225_g_x.rs
@@ -1,0 +1,25 @@
+use rstest::rstest;
+
+use super::super::common;
+
+/// `ac-abc225-g-x` バイナリへのパス。
+const BIN: &str = env!("CARGO_BIN_EXE_ac-abc225-g-x");
+
+// ac-abc225-g-x のテスト: 標準入力にサンプルを与えたときの標準出力を検証する
+mod ac_abc225_g_x {
+    use super::*;
+
+    /// Scenario: 問題文の公式サンプルを解いたときの標準出力を検証する
+    /// - Given: 問題文の公式サンプルである
+    /// - When: ac-abc225-g-x バイナリへ標準入力として渡す
+    /// - Then: スコアの最大値が期待値と一致する
+    #[rstest]
+    #[case::sample_1("2 2 2\n2 10\n8 3\n", "12\n")]
+    #[case::sample_2_none_is_best("3 3 100\n1 1 1\n1 1 1\n1 1 1\n", "0\n")]
+    fn matches_official_samples(#[case] input: &str, #[case] expected: &str) {
+        // When
+        let result = common::run_binary(BIN, input);
+        // Then
+        assert_eq!(expected, result);
+    }
+}

--- a/tests/bin/atcoder/abc326_g_unlock_achievement.rs
+++ b/tests/bin/atcoder/abc326_g_unlock_achievement.rs
@@ -1,0 +1,29 @@
+use rstest::rstest;
+
+use super::super::common;
+
+/// `ac-abc326-g-unlock-achievement` バイナリへのパス。
+const BIN: &str = env!("CARGO_BIN_EXE_ac-abc326-g-unlock-achievement");
+
+// ac-abc326-g-unlock-achievement のテスト: 標準入力にサンプルを与えたときの標準出力を検証する
+mod ac_abc326_g_unlock_achievement {
+    use super::*;
+
+    /// Scenario: 問題文の公式サンプルを解いたときの標準出力を検証する
+    /// - Given: 問題文の公式サンプルである
+    /// - When: ac-abc326-g-unlock-achievement バイナリへ標準入力として渡す
+    /// - Then: 得られる金額の最大値が期待値と一致する
+    #[rstest]
+    #[case::sample_1("2 2\n10 20\n100 50\n3 1\n1 4\n", "80\n")]
+    #[case::sample_2("2 2\n10 20\n100 50\n3 2\n1 4\n", "70\n")]
+    #[case::sample_3(
+        "10 10\n10922 23173 32300 22555 29525 16786 3135 17046 11245 20310\n177874 168698 202247 31339 10336 14825 56835 6497 12440 110702\n2 1 4 1 3 4 4 5 1 4\n2 3 4 4 5 3 5 5 2 3\n2 3 5 1 4 2 2 2 2 5\n3 5 5 3 5 2 2 1 5 4\n3 1 1 4 4 1 1 5 3 1\n1 2 3 2 4 2 4 3 3 1\n4 4 4 2 5 1 4 2 2 2\n5 3 1 2 3 4 2 5 2 2\n5 4 3 4 3 1 5 1 5 4\n2 3 2 5 2 3 1 2 2 4\n",
+        "66900\n"
+    )]
+    fn matches_official_samples(#[case] input: &str, #[case] expected: &str) {
+        // When
+        let result = common::run_binary(BIN, input);
+        // Then
+        assert_eq!(expected, result);
+    }
+}

--- a/tests/bin/atcoder/arc085_e_mul.rs
+++ b/tests/bin/atcoder/arc085_e_mul.rs
@@ -1,0 +1,27 @@
+use rstest::rstest;
+
+use super::super::common;
+
+/// `ac-arc085-e-mul` バイナリへのパス。
+const BIN: &str = env!("CARGO_BIN_EXE_ac-arc085-e-mul");
+
+// ac-arc085-e-mul のテスト: 標準入力にサンプルを与えたときの標準出力を検証する
+mod ac_arc085_e_mul {
+    use super::*;
+
+    /// Scenario: 問題文の公式サンプルを解いたときの標準出力を検証する
+    /// - Given: 問題文の公式サンプルである
+    /// - When: ac-arc085-e-mul バイナリへ標準入力として渡す
+    /// - Then: 得られるお金の最大値が期待値と一致する
+    #[rstest]
+    #[case::sample_1("6\n1 2 -6 4 5 3\n", "12\n")]
+    #[case::sample_2("6\n100 -100 -100 -100 100 -100\n", "200\n")]
+    #[case::sample_3_all_negative("5\n-1 -2 -3 -4 -5\n", "0\n")]
+    #[case::sample_4("2\n-1000 100000\n", "99000\n")]
+    fn matches_official_samples(#[case] input: &str, #[case] expected: &str) {
+        // When
+        let result = common::run_binary(BIN, input);
+        // Then
+        assert_eq!(expected, result);
+    }
+}

--- a/tests/bin/atcoder/practice2_d_maxflow.rs
+++ b/tests/bin/atcoder/practice2_d_maxflow.rs
@@ -1,0 +1,90 @@
+use super::super::common;
+
+/// `ac-practice2-d-maxflow` バイナリへのパス。
+const BIN: &str = env!("CARGO_BIN_EXE_ac-practice2-d-maxflow");
+
+// ac-practice2-d-maxflow のテスト: 標準入力にサンプルを与えたときの
+// 標準出力を検証する
+mod ac_practice2_d_maxflow {
+    use super::*;
+
+    /// Scenario: 出力されたドミノの配置が、実際に矛盾なく敷き詰められている
+    /// - Given: 問題文の公式サンプルである
+    /// - When: ac-practice2-d-maxflow バイナリへ標準入力として渡す
+    /// - Then: 出力された枚数が期待値 (3) と一致し、盤面の各ドミノが
+    ///   隣接する2マスの組として正しく対応しており、障害物 `#` の位置も
+    ///   保たれている
+    #[test]
+    fn produces_valid_domino_tiling() {
+        // Given
+        let input = "3 3\n#..\n..#\n...\n";
+        let grid = ["#..", "..#", "..."];
+        let expected_count = 3;
+        // When
+        let output = common::run_binary(BIN, input);
+        // Then
+        let mut lines = output.lines();
+
+        let count = lines.next().unwrap().parse::<usize>().unwrap();
+        assert_eq!(expected_count, count);
+
+        let board = lines
+            .map(|line| line.chars().collect::<Vec<char>>())
+            .collect::<Vec<_>>();
+        assert_eq!(grid.len(), board.len());
+
+        let n = board.len();
+        let m = board[0].len();
+        let mut placed_count = 0;
+        for (i, row) in board.iter().enumerate() {
+            assert_eq!(m, row.len());
+            for (j, &ch) in row.iter().enumerate() {
+                let original = grid[i].as_bytes()[j] as char;
+                if original == '#' {
+                    assert_eq!('#', ch, "obstacle at ({i}, {j}) must be preserved");
+                    continue;
+                }
+
+                match ch {
+                    '.' => {}
+                    '>' => {
+                        assert!(j + 1 < m, "'>' at ({i}, {j}) has no right neighbor");
+                        assert_eq!(
+                            '<',
+                            board[i][j + 1],
+                            "'>' at ({i}, {j}) is not paired with '<'"
+                        );
+                        placed_count += 1;
+                    }
+                    '<' => {
+                        assert!(j >= 1, "'<' at ({i}, {j}) has no left neighbor");
+                        assert_eq!(
+                            '>',
+                            board[i][j - 1],
+                            "'<' at ({i}, {j}) is not paired with '>'"
+                        );
+                    }
+                    'v' => {
+                        assert!(i + 1 < n, "'v' at ({i}, {j}) has no neighbor below");
+                        assert_eq!(
+                            '^',
+                            board[i + 1][j],
+                            "'v' at ({i}, {j}) is not paired with '^'"
+                        );
+                        placed_count += 1;
+                    }
+                    '^' => {
+                        assert!(i >= 1, "'^' at ({i}, {j}) has no neighbor above");
+                        assert_eq!(
+                            'v',
+                            board[i - 1][j],
+                            "'^' at ({i}, {j}) is not paired with 'v'"
+                        );
+                    }
+                    other => panic!("unexpected character '{other}' at ({i}, {j})"),
+                }
+            }
+        }
+        assert_eq!(expected_count, placed_count);
+    }
+}

--- a/tests/bin/atcoder/typical90_an_get_more_money.rs
+++ b/tests/bin/atcoder/typical90_an_get_more_money.rs
@@ -1,0 +1,25 @@
+use rstest::rstest;
+
+use super::super::common;
+
+/// `ac-typical90-an-get-more-money` バイナリへのパス。
+const BIN: &str = env!("CARGO_BIN_EXE_ac-typical90-an-get-more-money");
+
+// ac-typical90-an-get-more-money のテスト: 標準入力にサンプルを与えたときの標準出力を検証する
+mod ac_typical90_an_get_more_money {
+    use super::*;
+
+    /// Scenario: 問題文の公式サンプルを解いたときの標準出力を検証する
+    /// - Given: 問題文の公式サンプルである
+    /// - When: ac-typical90-an-get-more-money バイナリへ標準入力として渡す
+    /// - Then: 最終的に得る金額の最大値が期待値と一致する
+    #[rstest]
+    #[case::sample_1("5 5\n5 2 10 3 6\n1 3\n1 3\n0\n1 5\n0\n", "2\n")]
+    #[case::sample_2_none_is_best("6 10\n8 6 9 1 2 0\n1 3\n2 3 4\n1 5\n1 5\n1 6\n0\n", "0\n")]
+    fn matches_official_samples(#[case] input: &str, #[case] expected: &str) {
+        // When
+        let result = common::run_binary(BIN, input);
+        // Then
+        assert_eq!(expected, result);
+    }
+}

--- a/tests/bin/codeforces/cf1082g_petya_and_graph.rs
+++ b/tests/bin/codeforces/cf1082g_petya_and_graph.rs
@@ -1,0 +1,25 @@
+use rstest::rstest;
+
+use super::super::common;
+
+/// `cf-cf1082g-petya-and-graph` バイナリへのパス。
+const BIN: &str = env!("CARGO_BIN_EXE_cf-cf1082g-petya-and-graph");
+
+// cf-cf1082g-petya-and-graph のテスト: 標準入力にサンプルを与えたときの標準出力を検証する
+mod cf_cf1082g_petya_and_graph {
+    use super::*;
+
+    /// Scenario: 問題文の公式サンプルを解いたときの標準出力を検証する
+    /// - Given: 問題文の公式サンプルである
+    /// - When: cf-cf1082g-petya-and-graph バイナリへ標準入力として渡す
+    /// - Then: 部分グラフの最大重みが期待値と一致する
+    #[rstest]
+    #[case::sample_1("4 5\n1 5 2 2\n1 3 4\n1 4 4\n3 4 5\n3 2 2\n4 2 2\n", "8\n")]
+    #[case::sample_2_empty_is_best("3 3\n9 7 8\n1 2 1\n2 3 2\n1 3 3\n", "0\n")]
+    fn matches_official_samples(#[case] input: &str, #[case] expected: &str) {
+        // When
+        let result = common::run_binary(BIN, input);
+        // Then
+        assert_eq!(expected, result);
+    }
+}

--- a/tests/bin/library_checker/assignment.rs
+++ b/tests/bin/library_checker/assignment.rs
@@ -1,0 +1,48 @@
+use super::super::common;
+
+/// `lc-assignment` バイナリへのパス。
+const BIN: &str = env!("CARGO_BIN_EXE_lc-assignment");
+
+// lc-assignment のテスト: 標準入力にサンプルを与えたときの標準出力を検証する
+mod lc_assignment {
+    use super::*;
+
+    /// Scenario: 出力された割り当てが、実際に最小コストの順列になっている
+    /// - Given: 問題文の公式サンプルである
+    /// - When: lc-assignment バイナリへ標準入力として渡す
+    /// - Then: 出力されたコストが期待値 (9) と一致し、出力された `p_i` が
+    ///   `0..n` の順列をなし、その順列で行列を評価した合計が出力された
+    ///   コストと一致する
+    #[test]
+    fn produces_permutation_matching_minimum_cost() {
+        // Given
+        let input = "3\n4 3 5\n3 5 9\n4 1 4\n";
+        let matrix = [[4, 3, 5], [3, 5, 9], [4, 1, 4]];
+        let expected_cost = 9;
+        // When
+        let output = common::run_binary(BIN, input);
+        // Then
+        let mut tokens = output.split_whitespace();
+
+        let cost = tokens.next().unwrap().parse::<i64>().unwrap();
+        assert_eq!(expected_cost, cost);
+
+        let n = matrix.len();
+        let assignment = (0..n)
+            .map(|_| tokens.next().unwrap().parse::<usize>().unwrap())
+            .collect::<Vec<usize>>();
+        assert!(tokens.next().is_none());
+
+        // p が 0..n の順列であること (同じ列が2回使われていないこと) を、
+        // 出現した列を記録して確認する。
+        let mut used_columns = vec![false; n];
+        for &p in &assignment {
+            assert!(p < n, "column index {p} out of range");
+            assert!(!used_columns[p], "column {p} is used more than once");
+            used_columns[p] = true;
+        }
+
+        let actual_cost = (0..n).map(|i| matrix[i][assignment[i]]).sum::<i64>();
+        assert_eq!(expected_cost, actual_cost);
+    }
+}

--- a/tests/bin/poj/poj2987_firing.rs
+++ b/tests/bin/poj/poj2987_firing.rs
@@ -1,0 +1,26 @@
+use rstest::rstest;
+
+use super::super::common;
+
+/// `poj-poj2987-firing` バイナリへのパス。
+const BIN: &str = env!("CARGO_BIN_EXE_poj-poj2987-firing");
+
+// poj-poj2987-firing のテスト: 標準入力にサンプルを与えたときの標準出力を検証する
+mod poj_poj2987_firing {
+    use super::*;
+
+    /// Scenario: 与えられた入力を解いたときの標準出力を検証する
+    /// - Given: 公式サンプル、および手計算で検証した小規模なケースである
+    /// - When: poj-poj2987-firing バイナリへ標準入力として渡す
+    /// - Then: 最大利益を達成する最小の解雇人数と、その最大利益が期待値と一致する
+    #[rstest]
+    #[case::official_sample("5 5\n8\n-9\n-20\n12\n-10\n1 2\n2 5\n1 4\n3 4\n4 5\n", "2 2\n")]
+    #[case::firing_costs_more_than_it_saves("1 0\n-5\n", "0 0\n")]
+    #[case::firing_alone_is_profitable("1 0\n5\n", "1 5\n")]
+    fn matches_expected_output(#[case] input: &str, #[case] expected: &str) {
+        // When
+        let result = common::run_binary(BIN, input);
+        // Then
+        assert_eq!(expected, result);
+    }
+}

--- a/tests/bin/yukicoder/yuki2713_just_solitaire.rs
+++ b/tests/bin/yukicoder/yuki2713_just_solitaire.rs
@@ -1,0 +1,25 @@
+use rstest::rstest;
+
+use super::super::common;
+
+/// `yuki-yuki2713-just-solitaire` バイナリへのパス。
+const BIN: &str = env!("CARGO_BIN_EXE_yuki-yuki2713-just-solitaire");
+
+// yuki-yuki2713-just-solitaire のテスト: 標準入力にサンプルを与えたときの標準出力を検証する
+mod yuki_yuki2713_just_solitaire {
+    use super::*;
+
+    /// Scenario: 問題文の公式サンプルを解いたときの標準出力を検証する
+    /// - Given: 問題文の公式サンプルである
+    /// - When: yuki-yuki2713-just-solitaire バイナリへ標準入力として渡す
+    /// - Then: 得ることのできる利益の最大値が期待値と一致する
+    #[rstest]
+    #[case::sample_1("5 2\n10 20 30 40 50\n50 120\n3 1 2 3\n2 4 5\n", "30\n")]
+    #[case::sample_2_uses_all_cards("5 2\n10 20 30 40 50\n50 120\n3 1 2 3\n5 1 2 3 4 5\n", "20\n")]
+    fn matches_official_samples(#[case] input: &str, #[case] expected: &str) {
+        // When
+        let result = common::run_binary(BIN, input);
+        // Then
+        assert_eq!(expected, result);
+    }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -34,6 +34,7 @@ pub mod bin {
     }
 
     pub mod library_checker {
+        pub mod assignment;
         pub mod convolution_mod;
         pub mod cycle_detection;
         pub mod eulerian_trail_directed;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,12 @@ pub mod bin {
     pub mod atcoder {
         pub mod abc075_c_bridge;
         pub mod abc176_d_wizard_in_maze;
+        pub mod abc193_f_zebraness;
         pub mod abc209_d_collision;
+        pub mod abc225_g_x;
+        pub mod abc326_g_unlock_achievement;
+        pub mod arc085_e_mul;
+        pub mod typical90_an_get_more_money;
         pub mod typical90_aq_maze_challenge_with_lack_of_sleep;
         pub mod typical90_bs_fuzzy_priority;
         pub mod typical90_m_passing;
@@ -31,6 +36,18 @@ pub mod bin {
         pub mod grl_1_c_all_pairs_shortest_path;
         pub mod grl_1_c_all_pairs_shortest_path_johnson;
         pub mod grl_4_b_topological_sort;
+    }
+
+    pub mod yukicoder {
+        pub mod yuki2713_just_solitaire;
+    }
+
+    pub mod codeforces {
+        pub mod cf1082g_petya_and_graph;
+    }
+
+    pub mod poj {
+        pub mod poj2987_firing;
     }
 
     pub mod library_checker {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -21,6 +21,7 @@ pub mod bin {
         pub mod fps24_l_permutation2;
         pub mod fps24_m_connected_graph;
         pub mod fps24_n_coin2;
+        pub mod practice2_d_maxflow;
     }
 
     pub mod aoj {

--- a/tools/bundle.py
+++ b/tools/bundle.py
@@ -1,7 +1,8 @@
 """
-Library Checker / AtCoder / CodeChef / AOJ / Baekjoon / POJ 提出用に、
-src/bin/{library_checker,atcoder,codechef,aoj,baekjoon,poj}/<slug>.rs を
-単一ファイルへバンドルし、続けて不要コードを枝刈りするスクリプトである。
+Library Checker / AtCoder / CodeChef / AOJ / Baekjoon / POJ / yukicoder /
+Codeforces 提出用に、
+src/bin/{library_checker,atcoder,codechef,aoj,baekjoon,poj,yukicoder,codeforces}/
+<slug>.rs を単一ファイルへバンドルし、続けて不要コードを枝刈りするスクリプトである。
 
 使い方:
     python3 tools/bundle.py <slug> [<slug> ...]    # 指定した問題をバンドル + 枝刈り
@@ -10,12 +11,13 @@ src/bin/{library_checker,atcoder,codechef,aoj,baekjoon,poj}/<slug>.rs を
 
 新しい問題を追加する場合は、src/bin/library_checker/<slug>.rs、
 src/bin/atcoder/<slug>.rs、src/bin/codechef/<slug>.rs、src/bin/aoj/<slug>.rs、
-src/bin/baekjoon/<slug>.rs、または src/bin/poj/<slug>.rs を作成し (先頭 2 行が
+src/bin/baekjoon/<slug>.rs、src/bin/poj/<slug>.rs、src/bin/yukicoder/<slug>.rs、
+または src/bin/codeforces/<slug>.rs を作成し (先頭 2 行が
 `// Library Checker: <題名>` / `// AtCoder: <題名>` / `// CodeChef: <題名>` /
-`// AOJ: <題名>` / `// Baekjoon: <題名>` / `// POJ: <題名>` と `// <URL>`
-になっている前提)、Cargo.toml にバンドル後のバイナリーを登録したうえで
-`python3 tools/bundle.py <slug>` を実行するだけでよい。どのモジュールを
-取り込むかを手で指定する必要はない。
+`// AOJ: <題名>` / `// Baekjoon: <題名>` / `// POJ: <題名>` / `// yukicoder: <題名>` /
+`// Codeforces: <題名>` と `// <URL>` になっている前提)、Cargo.toml にバンドル後の
+バイナリーを登録したうえで `python3 tools/bundle.py <slug>` を実行するだけでよい。
+どのモジュールを取り込むかを手で指定する必要はない。
 
 バンドル後のバイナリーは生成物であってリポジトリーには含めないため、Cargo.toml へは
 `required-features = ["bundled"]` を添えて登録する。こうしておかないと、生成前の
@@ -53,6 +55,8 @@ SRC_DIRS = {
     "AOJ": REPO / "src/bin/aoj",
     "Baekjoon": REPO / "src/bin/baekjoon",
     "POJ": REPO / "src/bin/poj",
+    "yukicoder": REPO / "src/bin/yukicoder",
+    "Codeforces": REPO / "src/bin/codeforces",
 }
 BIN_PREFIX = {
     "Library Checker": "lc",
@@ -61,6 +65,8 @@ BIN_PREFIX = {
     "AOJ": "aoj",
     "Baekjoon": "bj",
     "POJ": "poj",
+    "yukicoder": "yuki",
+    "Codeforces": "cf",
 }
 
 # 枝刈りを繰り返す上限。トレイト実装の除去が新たな dead_code を生むため、
@@ -286,13 +292,14 @@ def extract_source(src_path):
     lines = text.split("\n")
 
     title_match = re.match(
-        r"^// (Library Checker|AtCoder|CodeChef|AOJ|Baekjoon|POJ): (.+)$", lines[0]
+        r"^// (Library Checker|AtCoder|CodeChef|AOJ|Baekjoon|POJ|yukicoder|Codeforces): (.+)$",
+        lines[0],
     )
     if not title_match:
         raise RuntimeError(
             f"{src_path}: 1 行目が '// Library Checker: ...' / '// AtCoder: ...' / "
-            "'// CodeChef: ...' / '// AOJ: ...' / '// Baekjoon: ...' / '// POJ: ...' "
-            "形式ではない"
+            "'// CodeChef: ...' / '// AOJ: ...' / '// Baekjoon: ...' / '// POJ: ...' / "
+            "'// yukicoder: ...' / '// Codeforces: ...' 形式ではない"
         )
     source, title = title_match.groups()
 


### PR DESCRIPTION
## 本PRに対応するIssue

Closes #38

## 本PRで行った変更の概要

- Dinic 法による最大流の計算を追加
- ポテンシャルを用いた successive shortest path 法による最小費用流の計算を追加
- AtCoder Library Practice Contest D 提出用バイナリーを追加
- Library Checker `Assignment Problem` 提出用バイナリーを追加

## 動作を確認する手順

`cargo test --workspace` で全テストが成功することを確認済み。
